### PR TITLE
Create new untyped parser context for each chunk

### DIFF
--- a/parser/src/main/java/io/jafar/parser/impl/UntypedParserContextFactory.java
+++ b/parser/src/main/java/io/jafar/parser/impl/UntypedParserContextFactory.java
@@ -18,20 +18,20 @@ public final class UntypedParserContextFactory implements ParserContextFactory {
      * </p>
      */
     public UntypedParserContextFactory() {}
-    
+
     /**
      * Creates a new parser context for the specified chunk.
      * <p>
-     * If a parent context is provided, it is reused; otherwise, a new
-     * UntypedParserContext is created for the specified chunk index.
+     * The parent context is ignored. The untyped parser will always create
+     * a fresh context.
      * </p>
-     * 
-     * @param parent the parent parser context, or {@code null} to create a new one
+     *
+     * @param parent the parent parser context (ignored)
      * @param chunkIndex the index of the chunk to create a context for
      * @return a parser context suitable for parsing the specified chunk
      */
     @Override
     public ParserContext newContext(ParserContext parent, int chunkIndex) {
-        return parent != null ? parent : new UntypedParserContext(chunkIndex);
+        return new UntypedParserContext(chunkIndex);
     }
 }


### PR DESCRIPTION
Inheriting from parent context was wrong - it creates concurrency issues and for untyped parser we really don't need to share anything across chunks/recording slices.