### PR TITLE
Make the time conversion API more friendly

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,10 +91,3 @@ allprojects {
         dependsOn rootProject.tasks.named('spotlessCheck')
     }
 }
-
-// Also enforce formatting when running tests directly
-allprojects {
-    tasks.withType(Test).configureEach {
-        dependsOn rootProject.tasks.named('spotlessCheck')
-    }
-}

--- a/parser/src/main/java/io/jafar/parser/api/Control.java
+++ b/parser/src/main/java/io/jafar/parser/api/Control.java
@@ -2,7 +2,6 @@ package io.jafar.parser.api;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Control utilities available to handlers during parsing. Provides access to the current stream
@@ -12,8 +11,8 @@ public interface Control {
   /**
    * A chunk info wrapper. <br>
    * Provides information like chunk start time, chunk duration and size. It also provides the
-   * {@linkplain ChunkInfo#convertTicks(long, TimeUnit)} method to easily convert time value in
-   * ticks into the desired time unit.
+   * {@linkplain ChunkInfo#asDuration(long)} method to easily convert time value in ticks into the
+   * desired time unit.
    */
   interface ChunkInfo {
     ChunkInfo NONE = new ChunkInfo() {};
@@ -49,12 +48,15 @@ public interface Control {
      * Convenience method to quickly covert the ticks value into the desired time unit
      *
      * @param ticks the ticks value
-     * @param unit the requested time unit
-     * @return the ticks converted to the requested time unit or -1 if there is no info available to
-     *     perform the conversion
+     * @return the ticks converted to the duration or {@code Duration.ofNanos(0)} if there is no
+     *     info available to perform the conversion
      */
-    default long convertTicks(long ticks, TimeUnit unit) {
-      return -1;
+    default Duration asDuration(long ticks) {
+      return Duration.ofNanos(0);
+    }
+
+    default Instant asInstant(long ticks) {
+      return Instant.ofEpochMilli(0);
     }
   }
 

--- a/parser/src/main/java/io/jafar/parser/api/ParserContext.java
+++ b/parser/src/main/java/io/jafar/parser/api/ParserContext.java
@@ -9,8 +9,8 @@ import java.util.concurrent.ConcurrentMap;
 /**
  * Per-session parsing context used internally and exposed via events.
  *
- * <p>Maintains per-parser reusable buffers and a key-value bag for extensions.
- * Values may be reclaimed by the GC at any time.
+ * <p>Maintains per-parser reusable buffers and a key-value bag for extensions. Values may be
+ * reclaimed by the GC at any time.
  *
  * <p>Not intended for direct instantiation by users.
  */

--- a/parser/src/main/java/io/jafar/parser/api/ParserContext.java
+++ b/parser/src/main/java/io/jafar/parser/api/ParserContext.java
@@ -3,21 +3,20 @@ package io.jafar.parser.api;
 import io.jafar.parser.internal_api.MutableConstantPools;
 import io.jafar.parser.internal_api.MutableMetadataLookup;
 import io.jafar.utils.CachedStringParser;
-import java.lang.ref.SoftReference;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 /**
  * Per-session parsing context used internally and exposed via events.
  *
- * <p>Maintains per-parser reusable buffers and a soft-referenced key-value bag for extensions.
+ * <p>Maintains per-parser reusable buffers and a key-value bag for extensions.
  * Values may be reclaimed by the GC at any time.
  *
  * <p>Not intended for direct instantiation by users.
  */
 public abstract class ParserContext {
-  /** Concurrent map for storing soft-referenced values by string keys. */
-  private final ConcurrentMap<String, SoftReference<?>> bag = new ConcurrentHashMap<>();
+  /** Concurrent map for storing values by string keys. */
+  private final ConcurrentMap<String, Object> bag = new ConcurrentHashMap<>();
 
   /** Metadata lookup instance for resolving metadata during parsing. */
   protected final MutableMetadataLookup metadataLookup;
@@ -73,8 +72,7 @@ public abstract class ParserContext {
    * @return the removed value, or {@code null} if it was reclaimed or not found
    */
   public final <T> T remove(Class<T> clz) {
-    SoftReference<?> removed = bag.remove(clz.getName());
-    return removed != null ? clz.cast(removed.get()) : null;
+    return clz.cast(bag.remove(clz.getName()));
   }
 
   /**
@@ -87,19 +85,18 @@ public abstract class ParserContext {
    * @return the removed value, or {@code null} if it was reclaimed
    */
   public final <T> T remove(String key, Class<T> clz) {
-    SoftReference<?> ref = bag.remove(key);
-    return ref != null ? clz.cast(ref.get()) : null;
+    return clz.cast(bag.remove(key));
   }
 
   /**
-   * Stores a value under the class name key with soft reference.
+   * Stores a value under the class name key.
    *
    * @param <T> the type of the value to store
    * @param clz the class whose name is used as the key
    * @param value the value to store
    */
   public final <T> void put(Class<T> clz, T value) {
-    bag.put(clz.getName(), new SoftReference<>(value));
+    bag.put(clz.getName(), value);
   }
 
   /**
@@ -110,12 +107,11 @@ public abstract class ParserContext {
    * @return the value, or {@code null} if it was reclaimed or not found
    */
   public final <T> T get(Class<T> clz) {
-    SoftReference<?> ref = bag.get(clz.getName());
-    return ref != null ? clz.cast(ref.get()) : null;
+    return clz.cast(bag.get(clz.getName()));
   }
 
   /**
-   * Stores a value under a custom key with soft reference.
+   * Stores a value under a custom key
    *
    * @param <T> the type of the value to store
    * @param key the custom key to use
@@ -123,7 +119,7 @@ public abstract class ParserContext {
    * @param value the value to store
    */
   public final <T> void put(String key, Class<T> clz, T value) {
-    bag.put(key, new SoftReference<>(value));
+    bag.put(key, value);
   }
 
   /**
@@ -137,8 +133,7 @@ public abstract class ParserContext {
    * @return the value or {@code null}
    */
   public final <T> T get(String key, Class<T> clz) {
-    SoftReference<?> ref = bag.get(key);
-    return ref != null ? clz.cast(ref.get()) : null;
+    return clz.cast(bag.get(key));
   }
 
   /** Clears all stored values from the context. */

--- a/parser/src/test/java/io/jafar/parser/UntypedJafarParserTest.java
+++ b/parser/src/test/java/io/jafar/parser/UntypedJafarParserTest.java
@@ -12,6 +12,8 @@ import io.jafar.parser.api.UntypedJafarParser;
 import java.io.File;
 import java.net.URI;
 import java.nio.file.Paths;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 
@@ -21,6 +23,7 @@ public class UntypedJafarParserTest {
   void testUntypedParsingCountsEvents() throws Exception {
     URI uri = TypedJafarParserTest.class.getClassLoader().getResource("test-ap.jfr").toURI();
     ParsingContext ctx = ParsingContext.create();
+    Instant cutOffDate = Instant.parse("2024-08-13T16:24:00Z");
     try (UntypedJafarParser p = ctx.newUntypedParser(Paths.get(new File(uri).getAbsolutePath()))) {
       AtomicInteger count = new AtomicInteger();
       HandlerRegistration<?> reg =
@@ -28,7 +31,14 @@ public class UntypedJafarParserTest {
               (t, v, ctl) -> {
                 assertNotNull(ctl.chunkInfo());
                 assertNotEquals(Control.ChunkInfo.NONE, ctl.chunkInfo());
+                Instant i = ctl.chunkInfo().asInstant((long) (v.get("startTime")));
+                assertTrue(
+                    i.isAfter(ctl.chunkInfo().startTime().minus(1, ChronoUnit.MILLIS)),
+                    i + " is not after " + ctl.chunkInfo().startTime());
+                assertTrue(i.isBefore(cutOffDate));
                 count.incrementAndGet();
+                // this is a sanity test only; we can end early
+                ctl.abort();
               });
       p.run();
       reg.destroy(p);


### PR DESCRIPTION
Modify the `ChunkInfo` API to allow directly converting ticks to `Duration` or `Instant`, using the correct baselines and calculations based on the chunk metadata.