### PR TITLE
Fix PluginRegistryTest to prevent remote registry fetches during testing

### DIFF
--- a/jfr-shell/src/test/java/io/jafar/shell/plugin/PluginRegistryTest.java
+++ b/jfr-shell/src/test/java/io/jafar/shell/plugin/PluginRegistryTest.java
@@ -30,9 +30,10 @@ class PluginRegistryTest {
 
     storageManager = mock(PluginStorageManager.class);
 
-    // Mock storage manager to return no cached data
-    when(storageManager.loadRegistryCache()).thenReturn(null);
-    when(storageManager.getRegistryCacheTime()).thenReturn(null);
+    // Mock storage manager to return empty remote registry (prevents GitHub fetch)
+    String emptyRegistry = "{\"plugins\": {}}";
+    when(storageManager.loadRegistryCache()).thenReturn(emptyRegistry);
+    when(storageManager.getRegistryCacheTime()).thenReturn(java.time.Instant.now());
 
     // Pass custom Maven repository path to avoid system property manipulation
     registry = new PluginRegistry(storageManager, mockMavenRepoRoot);


### PR DESCRIPTION
## Summary

Additional fix for PluginRegistryTest to ensure complete test isolation by preventing real HTTP requests to GitHub during test execution.

## Problem

Even after fixing the Maven repository path issue in PR #50, the tests were still failing because they were making **real HTTP requests** to:
```
https://raw.githubusercontent.com/btraceio/jafar/main/jfr-shell-plugins.json
```

This production registry contains:
- `jdk: 0.1.0-SNAPSHOT`
- `jafar: 0.1.0-SNAPSHOT`

Since `PluginRegistry` prioritizes remote plugins over local ones (line 79-83 in PluginRegistry.java), the tests always found these production versions instead of the mocked `0.9.0-SNAPSHOT` and `0.9.1-SNAPSHOT` versions they created.

## Solution

Changed the mock in `setUp()` from returning `null` (which triggers a GitHub fetch) to returning an empty registry JSON with current timestamp:

```java
// Before: returned null, causing GitHub fetch
when(storageManager.loadRegistryCache()).thenReturn(null);
when(storageManager.getRegistryCacheTime()).thenReturn(null);

// After: returns empty registry, prevents GitHub fetch
String emptyRegistry = "{\"plugins\": {}}";
when(storageManager.loadRegistryCache()).thenReturn(emptyRegistry);
when(storageManager.getRegistryCacheTime()).thenReturn(java.time.Instant.now());
```

This forces the registry to use only the mock local Maven repository data created by the tests.

## Test Results

All 11 tests in `PluginRegistryTest` now pass:
- ✅ `discoversPluginFromLocalMaven()`
- ✅ `discoversLatestVersionWhenMultipleExist()`
- ✅ `handlesMissingMavenRepository()`
- ✅ 8 other tests

Build time: 2 seconds (incremental compilation)

## Why This Matters

- **Test isolation**: Tests should not depend on external network services
- **Reliability**: Tests won't fail due to GitHub API rate limits or network issues
- **Speed**: No network latency during test execution
- **Determinism**: Tests always use controlled mock data

🤖 Generated with [Claude Code](https://claude.com/claude-code)