### PR TITLE
Handle SubstrateVM zero-payload JFR chunks in Scrubber

### DIFF
--- a/parser-core/src/main/java/io/jafar/parser/internal_api/StreamingChunkParser.java
+++ b/parser-core/src/main/java/io/jafar/parser/internal_api/StreamingChunkParser.java
@@ -83,12 +83,17 @@ public final class StreamingChunkParser implements AutoCloseable {
       ChunkHeader chunkHeader,
       RecordingStream chunkStream,
       ChunkParserListener listener,
-      long remainder) {
+      long headerSize) {
     return executor.submit(
         () -> {
           int chunkCounter = chunkHeader.order;
           ParserContext chunkContext = chunkStream.getContext();
           try {
+            // Skip empty chunks with no payload beyond the header
+            // (e.g. SubstrateVM may emit zero-payload chunks)
+            if (chunkHeader.size <= headerSize) {
+              return true;
+            }
             if (!listener.onChunkStart(chunkContext, chunkCounter, chunkHeader)) {
               log.debug(
                   "'onChunkStart' returned false. Skipping metadata and events for chunk {}",
@@ -108,7 +113,7 @@ public final class StreamingChunkParser implements AutoCloseable {
               listener.onChunkEnd(chunkContext, chunkCounter, true);
               return false;
             }
-            chunkStream.position(remainder);
+            chunkStream.position(headerSize);
             while (chunkStream.position() < chunkHeader.size) {
               long eventStartPos = chunkStream.position();
               chunkStream.mark(); // max 2 varints ahead
@@ -153,7 +158,7 @@ public final class StreamingChunkParser implements AutoCloseable {
       int chunkCounter = 1;
       while (stream.available() > 0) {
         ChunkHeader header = new ChunkHeader(stream, chunkCounter);
-        long remainder = (stream.position() - header.offset);
+        long headerSize = (stream.position() - header.offset);
 
         RecordingStream chunkStream =
             stream.slice(
@@ -162,7 +167,7 @@ public final class StreamingChunkParser implements AutoCloseable {
                 contextFactory.newContext(stream.getContext(), chunkCounter));
         stream.position(header.offset + header.size);
 
-        results.add(submitParsingTask(header, chunkStream, listener, remainder));
+        results.add(submitParsingTask(header, chunkStream, listener, headerSize));
         chunkCounter++;
       }
       results.forEach(

--- a/tools/src/main/java/io/jafar/tools/Scrubber.java
+++ b/tools/src/main/java/io/jafar/tools/Scrubber.java
@@ -135,8 +135,7 @@ public final class Scrubber {
     scrubFile(input, output, globalSkipInfo);
   }
 
-  private static void scrubFile(Path input, Path output, Set<SkipInfo> skipRanges)
-      throws Exception {
+  static void scrubFile(Path input, Path output, Set<SkipInfo> skipRanges) throws Exception {
     final int BUF_SIZE = 64 * 1024;
     ByteBuffer copyBuf = ByteBuffer.allocateDirect(BUF_SIZE);
     try (FileChannel in = FileChannel.open(input, StandardOpenOption.READ);
@@ -164,6 +163,14 @@ public final class Scrubber {
         // We need to compute the length of the string such that:
         // 1 + varintSize(payloadLen) + payloadLen == to - from
         long s = to - from - 1;
+        if (s <= 0) {
+          // Range too small for replacement (null/empty string encoding) — copy as-is
+          if (to > from) {
+            copyRegion(in, out, from, to - from, copyBuf);
+          }
+          pos = to;
+          continue;
+        }
         int payloadLen = computeFittingPayloadLength((int) s);
         if (payloadLen > BUF_SIZE) {
           throw new RuntimeException(
@@ -354,7 +361,8 @@ public final class Scrubber {
               skipInfo[0] = null; // do not scrub if guard condition is not met
             }
           }
-          if (skipInfo[0] != null) {
+          // Skip null/empty strings (1 byte encoding) — no sensitive data to scrub
+          if (skipInfo[0] != null && (skipInfo[0].endPos - skipInfo[0].startPos) > 1) {
             info.skipInfo.add(skipInfo[0]);
           }
         } catch (IOException ex) {

--- a/tools/src/test/java/io/jafar/tools/ScrubberTest.java
+++ b/tools/src/test/java/io/jafar/tools/ScrubberTest.java
@@ -9,6 +9,9 @@ import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.util.Comparator;
+import java.util.Set;
+import java.util.TreeSet;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -137,5 +140,52 @@ class ScrubberTest {
     }
 
     assertThat(Files.readAllBytes(dst)).isEmpty();
+  }
+
+  @Test
+  void scrubFileSkipsOneByteRange(@TempDir Path tempDir) throws Exception {
+    // Simulate a null/empty JFR string field (1 byte: type=0 or type=1)
+    byte[] data = {0x10, 0x20, 0x00, 0x30, 0x40};
+    Path src = tempDir.resolve("input.bin");
+    Path dst = tempDir.resolve("output.bin");
+    Files.write(src, data);
+
+    Set<Scrubber.SkipInfo> skipRanges = new TreeSet<>(Comparator.comparingLong(o -> o.endPos));
+    // 1-byte range at position 2 — should be passed through unchanged
+    skipRanges.add(new Scrubber.SkipInfo(2, 3));
+
+    Scrubber.scrubFile(src, dst, skipRanges);
+
+    // Output should be identical to input — the 1-byte range is copied as-is
+    assertThat(Files.readAllBytes(dst)).isEqualTo(data);
+  }
+
+  @Test
+  void scrubFileHandlesNormalRangeAfterSkippedOneByteRange(@TempDir Path tempDir) throws Exception {
+    // Mix of a 1-byte range (skipped) and a normal range (scrubbed)
+    // Positions: [0..4] prefix, [5] 1-byte null string, [6..9] 4-byte string field
+    byte[] data = {0x10, 0x20, 0x30, 0x40, 0x50, 0x00, 0x04, 'a', 'b', 'c', 0x60, 0x70};
+    Path src = tempDir.resolve("input.bin");
+    Path dst = tempDir.resolve("output.bin");
+    Files.write(src, data);
+
+    Set<Scrubber.SkipInfo> skipRanges = new TreeSet<>(Comparator.comparingLong(o -> o.endPos));
+    skipRanges.add(new Scrubber.SkipInfo(5, 6)); // 1-byte null string — skipped
+    skipRanges.add(new Scrubber.SkipInfo(6, 10)); // 4-byte field — scrubbed
+
+    Scrubber.scrubFile(src, dst, skipRanges);
+
+    byte[] result = Files.readAllBytes(dst);
+    assertThat(result).hasSize(data.length);
+    // Bytes before ranges are copied as-is
+    assertThat(result[0]).isEqualTo((byte) 0x10);
+    assertThat(result[4]).isEqualTo((byte) 0x50);
+    // 1-byte range at position 5 is copied as-is
+    assertThat(result[5]).isEqualTo((byte) 0x00);
+    // 4-byte range at positions 6..9 is replaced with type(4) + varint(2) + "xx"
+    assertThat(result[6]).isEqualTo((byte) 4); // string type
+    // Trailing bytes are copied as-is
+    assertThat(result[10]).isEqualTo((byte) 0x60);
+    assertThat(result[11]).isEqualTo((byte) 0x70);
   }
 }


### PR DESCRIPTION
## Summary

- Skip zero-payload JFR chunks in `StreamingChunkParser` (SubstrateVM may emit chunks with no data beyond the header)
- Skip scrubbing of null/empty string fields (1-byte JFR string encoding: type 0 or 1) in `Scrubber` — these contain no sensitive data
- Add defensive guard in `scrubFile()` to copy tiny ranges as-is instead of throwing `IllegalArgumentException`

## Test plan

- [x] New unit tests for 1-byte skip ranges (`scrubFileSkipsOneByteRange`, `scrubFileHandlesNormalRangeAfterSkippedOneByteRange`)
- [x] All existing `ScrubberTest` and `parser-core` tests pass
- [ ] Verify with an actual SubstrateVM-produced JFR recording

🤖 Generated with [Claude Code](https://claude.com/claude-code)