### PR TITLE
Fix EventIterator returning null for constant-pool-backed fields

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - '**'
 
+concurrency:
+  group: pr-tests-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/parser-codegen/src/main/java/io/jafar/parser/internal_api/UntypedCodeGenerator.java
+++ b/parser-codegen/src/main/java/io/jafar/parser/internal_api/UntypedCodeGenerator.java
@@ -490,25 +490,39 @@ public final class UntypedCodeGenerator {
       return;
     }
 
-    // Handle constant pool references - store as Long
+    // Handle constant pool references - wrap in ConstantPoolAccessor for lazy resolution
     if (field.hasConstantPool()) {
+      String cpAccessorName = Type.getInternalName(io.jafar.parser.impl.ConstantPoolAccessor.class);
+      long fieldTypeId = fieldType.getId();
       // Stack: [...]
+      mv.visitTypeInsn(Opcodes.NEW, cpAccessorName);
+      // Stack: [..., ConstantPoolAccessor]
+      mv.visitInsn(Opcodes.DUP);
+      // Stack: [..., ConstantPoolAccessor, ConstantPoolAccessor]
+      mv.visitVarInsn(Opcodes.ALOAD, contextVar); // ParserContext
+      // Stack: [..., ConstantPoolAccessor, ConstantPoolAccessor, ParserContext]
+      mv.visitLdcInsn(fieldTypeId); // type ID (compile-time constant)
+      // Stack: [..., ConstantPoolAccessor, ConstantPoolAccessor, ParserContext, long]
       mv.visitVarInsn(Opcodes.ALOAD, streamVar); // Load stream
-      // Stack: [..., RecordingStream]
+      // Stack: [..., ConstantPoolAccessor, ConstantPoolAccessor, ParserContext, long, Stream]
       mv.visitMethodInsn(
           Opcodes.INVOKEVIRTUAL,
           Type.getInternalName(RecordingStream.class),
           "readVarint",
           Type.getMethodDescriptor(Type.LONG_TYPE),
           false);
-      // Stack: [..., long]
+      // Stack: [..., ConstantPoolAccessor, ConstantPoolAccessor, ParserContext, long, long]
       mv.visitMethodInsn(
-          Opcodes.INVOKESTATIC,
-          Type.getInternalName(Long.class),
-          "valueOf",
-          Type.getMethodDescriptor(Type.getType(Long.class), Type.LONG_TYPE),
+          Opcodes.INVOKESPECIAL,
+          cpAccessorName,
+          "<init>",
+          Type.getMethodDescriptor(
+              Type.VOID_TYPE,
+              Type.getType(io.jafar.parser.api.ParserContext.class),
+              Type.LONG_TYPE,
+              Type.LONG_TYPE),
           false);
-      // Stack: [..., Long]
+      // Stack: [..., ConstantPoolAccessor]
       return;
     }
 

--- a/parser-codegen/src/test/java/io/jafar/parser/EventIteratorTest.java
+++ b/parser-codegen/src/test/java/io/jafar/parser/EventIteratorTest.java
@@ -316,6 +316,43 @@ public class EventIteratorTest {
     }
   }
 
+  /**
+   * Regression test for: EventIterator returning null for constant-pool-backed fields.
+   *
+   * <p>Before the fix, fields like {@code eventThread} and {@code stackTrace} appeared as raw
+   * {@code Long} CP pointers (or null) in the event value map instead of resolved Maps. The fix
+   * makes the untyped codegen emit a lazy {@link ComplexType} for CP-typed fields that resolves on
+   * demand via a pool-level cache.
+   */
+  @Test
+  void testCpBackedFieldsAreNotNull() throws Exception {
+    ParsingContext ctx = ParsingContext.create();
+
+    try (EventIterator it = EventIterator.open(syntheticJfr, ctx)) {
+      assertTrue(it.hasNext());
+      JafarRecordedEvent event = it.next();
+      Map<String, Object> value = event.value();
+
+      // eventThread is a CP-backed field — must be a ComplexType, never null or raw Long
+      Object eventThread = value.get("eventThread");
+      assertNotNull(eventThread, "eventThread must not be null (CP-backed field regression)");
+      assertInstanceOf(
+          ComplexType.class, eventThread, "eventThread must be a ComplexType, not a raw pointer");
+      Map<String, Object> threadMap = ((ComplexType) eventThread).getValue();
+      assertNotNull(threadMap, "eventThread CP entry must resolve to a non-null map");
+      assertNotNull(threadMap.get("javaName"), "eventThread must have javaName field");
+
+      // stackTrace is a CP-backed field — must resolve the same way
+      Object stackTrace = value.get("stackTrace");
+      assertNotNull(stackTrace, "stackTrace must not be null (CP-backed field regression)");
+      assertInstanceOf(
+          ComplexType.class, stackTrace, "stackTrace must be a ComplexType, not a raw pointer");
+      Map<String, Object> stackTraceMap = ((ComplexType) stackTrace).getValue();
+      assertNotNull(stackTraceMap, "stackTrace CP entry must resolve to a non-null map");
+      assertNotNull(stackTraceMap.get("frames"), "stackTrace must have frames field");
+    }
+  }
+
   @Test
   void testIteratorConstantPoolFieldsAreResolvable() throws Exception {
     ParsingContext ctx = ParsingContext.create();

--- a/parser-codegen/src/test/java/io/jafar/parser/EventIteratorTest.java
+++ b/parser-codegen/src/test/java/io/jafar/parser/EventIteratorTest.java
@@ -1,30 +1,90 @@
 package io.jafar.parser;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
+import io.jafar.TestJfrRecorder;
+import io.jafar.parser.api.ComplexType;
 import io.jafar.parser.api.EventIterator;
 import io.jafar.parser.api.JafarRecordedEvent;
 import io.jafar.parser.api.ParsingContext;
 import io.jafar.parser.api.UntypedJafarParser;
-import java.io.File;
-import java.net.URI;
-import java.nio.file.Paths;
+import io.jafar.parser.api.Values;
+import java.io.ByteArrayOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.concurrent.atomic.AtomicInteger;
+import jdk.jfr.Event;
+import jdk.jfr.Name;
+import jdk.jfr.StackTrace;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.openjdk.jmc.flightrecorder.writer.api.Recording;
+import org.openjdk.jmc.flightrecorder.writer.api.Recordings;
 
 public class EventIteratorTest {
 
+  @Name("io.jafar.test.IteratorTestEvent")
+  @StackTrace(true)
+  static class TestEvent extends Event {
+    int id;
+
+    TestEvent(int id) {
+      this.id = id;
+    }
+  }
+
+  private static Path syntheticJfr;
+  private static Path multiChunkJfr;
+
+  @BeforeAll
+  static void createTestJfrFiles() throws Exception {
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    try (Recording recording = Recordings.newRecording(bos)) {
+      TestJfrRecorder rec = new TestJfrRecorder(recording);
+      rec.registerEventType(TestEvent.class);
+      for (int i = 0; i < 100; i++) {
+        rec.writeEvent(new TestEvent(i));
+      }
+    }
+    syntheticJfr = Files.createTempFile("jafar-iterator-test", ".jfr");
+    Files.write(syntheticJfr, bos.toByteArray());
+
+    // Two-chunk recording: concatenate two independent single-chunk recordings.
+    // JFR format is a sequence of self-contained chunks, so this produces a valid two-chunk file.
+    bos = new ByteArrayOutputStream();
+    try (Recording r = Recordings.newRecording(bos)) {
+      TestJfrRecorder rec = new TestJfrRecorder(r);
+      rec.registerEventType(TestEvent.class);
+      for (int i = 0; i < 20; i++) rec.writeEvent(new TestEvent(i));
+    }
+    try (Recording r = Recordings.newRecording(bos)) {
+      TestJfrRecorder rec = new TestJfrRecorder(r);
+      rec.registerEventType(TestEvent.class);
+      for (int i = 20; i < 40; i++) rec.writeEvent(new TestEvent(i));
+    }
+    multiChunkJfr = Files.createTempFile("jafar-multi-chunk-test", ".jfr");
+    Files.write(multiChunkJfr, bos.toByteArray());
+  }
+
+  @AfterAll
+  static void deleteTestJfrFiles() throws Exception {
+    if (syntheticJfr != null) Files.deleteIfExists(syntheticJfr);
+    if (multiChunkJfr != null) Files.deleteIfExists(multiChunkJfr);
+  }
+
   @Test
   void testIteratorConsumesAllEvents() throws Exception {
-    URI uri = TypedJafarParserTest.class.getClassLoader().getResource("test-ap.jfr").toURI();
     ParsingContext ctx = ParsingContext.create();
 
     // Count events using iterator
     int iteratorCount = 0;
-    try (EventIterator it = EventIterator.open(Paths.get(new File(uri).getAbsolutePath()), ctx)) {
+    try (EventIterator it = EventIterator.open(syntheticJfr, ctx)) {
       while (it.hasNext()) {
         JafarRecordedEvent event = it.next();
         assertNotNull(event);
@@ -36,7 +96,7 @@ public class EventIteratorTest {
 
     // Count events using callback for comparison
     AtomicInteger callbackCount = new AtomicInteger();
-    try (UntypedJafarParser p = ctx.newUntypedParser(Paths.get(new File(uri).getAbsolutePath()))) {
+    try (UntypedJafarParser p = ctx.newUntypedParser(syntheticJfr)) {
       p.handle((t, v, ctl) -> callbackCount.incrementAndGet());
       p.run();
     }
@@ -51,13 +111,12 @@ public class EventIteratorTest {
 
   @Test
   void testIteratorEarlyTermination() throws Exception {
-    URI uri = TypedJafarParserTest.class.getClassLoader().getResource("test-ap.jfr").toURI();
     ParsingContext ctx = ParsingContext.create();
 
     int limit = 10;
     int count = 0;
 
-    try (EventIterator it = EventIterator.open(Paths.get(new File(uri).getAbsolutePath()), ctx)) {
+    try (EventIterator it = EventIterator.open(syntheticJfr, ctx)) {
       while (it.hasNext() && count < limit) {
         JafarRecordedEvent event = it.next();
         assertNotNull(event);
@@ -70,14 +129,13 @@ public class EventIteratorTest {
 
   @Test
   void testIteratorAllowsMutableVariables() throws Exception {
-    URI uri = TypedJafarParserTest.class.getClassLoader().getResource("test-ap.jfr").toURI();
     ParsingContext ctx = ParsingContext.create();
 
     // Plain variables - no AtomicInteger needed!
     int counter = 0;
     List<String> eventTypes = new ArrayList<>();
 
-    try (EventIterator it = EventIterator.open(Paths.get(new File(uri).getAbsolutePath()), ctx)) {
+    try (EventIterator it = EventIterator.open(syntheticJfr, ctx)) {
       while (it.hasNext()) {
         JafarRecordedEvent event = it.next();
         counter++; // Can mutate directly
@@ -95,10 +153,9 @@ public class EventIteratorTest {
 
   @Test
   void testIteratorEventDataIntegrity() throws Exception {
-    URI uri = TypedJafarParserTest.class.getClassLoader().getResource("test-ap.jfr").toURI();
     ParsingContext ctx = ParsingContext.create();
 
-    try (EventIterator it = EventIterator.open(Paths.get(new File(uri).getAbsolutePath()), ctx)) {
+    try (EventIterator it = EventIterator.open(syntheticJfr, ctx)) {
       if (it.hasNext()) {
         JafarRecordedEvent event = it.next();
 
@@ -124,10 +181,9 @@ public class EventIteratorTest {
 
   @Test
   void testIteratorContractCompliance() throws Exception {
-    URI uri = TypedJafarParserTest.class.getClassLoader().getResource("test-ap.jfr").toURI();
     ParsingContext ctx = ParsingContext.create();
 
-    try (EventIterator it = EventIterator.open(Paths.get(new File(uri).getAbsolutePath()), ctx)) {
+    try (EventIterator it = EventIterator.open(syntheticJfr, ctx)) {
       // hasNext() should be idempotent
       if (it.hasNext()) {
         assertTrue(it.hasNext(), "Multiple hasNext() calls should return same result");
@@ -160,61 +216,54 @@ public class EventIteratorTest {
 
   @Test
   void testIteratorWithCustomBufferSize() throws Exception {
-    URI uri = TypedJafarParserTest.class.getClassLoader().getResource("test-ap.jfr").toURI();
     ParsingContext ctx = ParsingContext.create();
 
-    // Small buffer
+    // Small buffer — all 100 events must arrive regardless of buffer size
     int count = 0;
-    try (EventIterator it =
-        EventIterator.open(Paths.get(new File(uri).getAbsolutePath()), ctx, 10)) {
+    try (EventIterator it = EventIterator.open(syntheticJfr, ctx, 10)) {
       while (it.hasNext()) {
         it.next();
         count++;
-        if (count > 20) break;
       }
     }
 
-    assertTrue(count > 0, "Should process events with small buffer");
+    assertEquals(100, count, "Should deliver all events with small buffer");
 
     // Large buffer
     count = 0;
-    try (EventIterator it =
-        EventIterator.open(Paths.get(new File(uri).getAbsolutePath()), ctx, 5000)) {
+    try (EventIterator it = EventIterator.open(syntheticJfr, ctx, 5000)) {
       while (it.hasNext()) {
         it.next();
         count++;
-        if (count > 20) break;
       }
     }
 
-    assertTrue(count > 0, "Should process events with large buffer");
+    assertEquals(100, count, "Should deliver all events with large buffer");
   }
 
   @Test
   void testIteratorInvalidBufferSize() throws Exception {
-    URI uri = TypedJafarParserTest.class.getClassLoader().getResource("test-ap.jfr").toURI();
     ParsingContext ctx = ParsingContext.create();
 
     assertThrows(
         IllegalArgumentException.class,
         () -> {
-          EventIterator.open(Paths.get(new File(uri).getAbsolutePath()), ctx, 0);
+          EventIterator.open(syntheticJfr, ctx, 0);
         });
 
     assertThrows(
         IllegalArgumentException.class,
         () -> {
-          EventIterator.open(Paths.get(new File(uri).getAbsolutePath()), ctx, -1);
+          EventIterator.open(syntheticJfr, ctx, -1);
         });
   }
 
   @Test
   void testIteratorCloseWithoutConsumption() throws Exception {
-    URI uri = TypedJafarParserTest.class.getClassLoader().getResource("test-ap.jfr").toURI();
     ParsingContext ctx = ParsingContext.create();
 
     // Open and close without consuming
-    try (EventIterator it = EventIterator.open(Paths.get(new File(uri).getAbsolutePath()), ctx)) {
+    try (EventIterator it = EventIterator.open(syntheticJfr, ctx)) {
       // Don't consume any events
     }
 
@@ -223,10 +272,9 @@ public class EventIteratorTest {
 
   @Test
   void testIteratorMultipleClose() throws Exception {
-    URI uri = TypedJafarParserTest.class.getClassLoader().getResource("test-ap.jfr").toURI();
     ParsingContext ctx = ParsingContext.create();
 
-    EventIterator it = EventIterator.open(Paths.get(new File(uri).getAbsolutePath()), ctx);
+    EventIterator it = EventIterator.open(syntheticJfr, ctx);
 
     // First close
     it.close();
@@ -240,27 +288,23 @@ public class EventIteratorTest {
 
   @Test
   void testIteratorDefaultBufferSize() throws Exception {
-    URI uri = TypedJafarParserTest.class.getClassLoader().getResource("test-ap.jfr").toURI();
-
-    // Should use default buffer size (1000)
+    // Should use default buffer size (1000) and deliver all 100 events
     int count = 0;
-    try (EventIterator it = EventIterator.open(Paths.get(new File(uri).getAbsolutePath()))) {
+    try (EventIterator it = EventIterator.open(syntheticJfr)) {
       while (it.hasNext()) {
         it.next();
         count++;
-        if (count > 100) break;
       }
     }
 
-    assertTrue(count > 0, "Should process events with default buffer");
+    assertEquals(100, count, "Should deliver all events with default buffer");
   }
 
   @Test
   void testIteratorChunkInfoAvailable() throws Exception {
-    URI uri = TypedJafarParserTest.class.getClassLoader().getResource("test-ap.jfr").toURI();
     ParsingContext ctx = ParsingContext.create();
 
-    try (EventIterator it = EventIterator.open(Paths.get(new File(uri).getAbsolutePath()), ctx)) {
+    try (EventIterator it = EventIterator.open(syntheticJfr, ctx)) {
       if (it.hasNext()) {
         JafarRecordedEvent event = it.next();
 
@@ -270,5 +314,100 @@ public class EventIteratorTest {
         assertTrue(event.chunkInfo().size() >= 0, "ChunkInfo should have valid size");
       }
     }
+  }
+
+  @Test
+  void testIteratorConstantPoolFieldsAreResolvable() throws Exception {
+    ParsingContext ctx = ParsingContext.create();
+
+    int cpFieldsResolved = 0;
+    try (EventIterator it = EventIterator.open(syntheticJfr, ctx)) {
+      while (it.hasNext()) {
+        JafarRecordedEvent event = it.next();
+        for (Map.Entry<String, Object> entry : event.value().entrySet()) {
+          Object value = entry.getValue();
+          if (value instanceof ComplexType) {
+            // Lazy CP reference — resolve it
+            Map<String, Object> resolved = ((ComplexType) value).getValue();
+            assertNotNull(
+                resolved,
+                "ComplexType field '"
+                    + entry.getKey()
+                    + "' in event "
+                    + event.typeName()
+                    + " should resolve to a non-null map");
+            assertFalse(
+                resolved.isEmpty(),
+                "Resolved CP field '" + entry.getKey() + "' should have at least one key");
+            cpFieldsResolved++;
+          }
+        }
+      }
+    }
+    assertTrue(cpFieldsResolved > 0, "Expected at least one CP-backed field to be resolved");
+  }
+
+  @Test
+  void testIteratorFieldValuesMatchCallback() throws Exception {
+    ParsingContext ctx = ParsingContext.create();
+
+    // Collect field values via callback-based parser
+    List<Map<String, Object>> callbackValues = new ArrayList<>();
+    try (UntypedJafarParser p = ctx.newUntypedParser(syntheticJfr)) {
+      p.handle((type, value, ctl) -> callbackValues.add(Values.resolvedDeep(value)));
+      p.run();
+    }
+
+    // Collect the same events via EventIterator
+    List<Map<String, Object>> iteratorValues = new ArrayList<>();
+    try (EventIterator it = EventIterator.open(syntheticJfr, ctx)) {
+      while (it.hasNext()) {
+        JafarRecordedEvent event = it.next();
+        iteratorValues.add(Values.resolvedDeep(event.value()));
+      }
+    }
+
+    assertEquals(
+        callbackValues.size(),
+        iteratorValues.size(),
+        "Iterator and callback should produce the same number of events");
+    // Use recursive comparison so that Object[] values (e.g. stackTrace frames) are compared by
+    // content, not by reference identity.
+    for (int i = 0; i < callbackValues.size(); i++) {
+      assertThat(iteratorValues.get(i))
+          .as("Event %d field values should match between callback and iterator", i)
+          .usingRecursiveComparison()
+          .isEqualTo(callbackValues.get(i));
+    }
+  }
+
+  @Test
+  void testIteratorMultiChunkCpResolution() throws Exception {
+    ParsingContext ctx = ParsingContext.create();
+
+    int totalEvents = 0;
+    int cpFieldsResolved = 0;
+    try (EventIterator it = EventIterator.open(multiChunkJfr, ctx)) {
+      while (it.hasNext()) {
+        JafarRecordedEvent event = it.next();
+        totalEvents++;
+        for (Map.Entry<String, Object> entry : event.value().entrySet()) {
+          Object value = entry.getValue();
+          if (value instanceof ComplexType) {
+            Map<String, Object> resolved = ((ComplexType) value).getValue();
+            assertNotNull(
+                resolved,
+                "CP field '"
+                    + entry.getKey()
+                    + "' in event "
+                    + event.typeName()
+                    + " should resolve across chunk boundary");
+            cpFieldsResolved++;
+          }
+        }
+      }
+    }
+    assertEquals(40, totalEvents, "Should see events from both chunks");
+    assertTrue(cpFieldsResolved > 0, "CP-backed fields should resolve in a multi-chunk recording");
   }
 }

--- a/parser-core/src/java21/java/io/jafar/parser/api/Values.java
+++ b/parser-core/src/java21/java/io/jafar/parser/api/Values.java
@@ -70,7 +70,8 @@ public final class Values {
 
   private static Object resolveDeepValue(Object v) {
     if (v instanceof ComplexType c) {
-      return resolvedDeep(c.getValue());
+      Map<String, Object> inner = c.getValue();
+      return inner != null ? resolvedDeep(inner) : null;
     }
     Object array = unwrapArray(v);
     if (array != null && array.getClass().isArray()) {

--- a/parser-core/src/main/java/io/jafar/parser/api/Values.java
+++ b/parser-core/src/main/java/io/jafar/parser/api/Values.java
@@ -119,7 +119,8 @@ public final class Values {
   private static Object resolveDeepValue(Object v) {
     if (v instanceof ComplexType) {
       ComplexType c = (ComplexType) v;
-      return resolvedDeep(c.getValue());
+      Map<String, Object> inner = c.getValue();
+      return inner != null ? resolvedDeep(inner) : null;
     }
     Object array = unwrapArray(v);
     if (array != null && array.getClass().isArray()) {

--- a/parser-core/src/main/java/io/jafar/parser/impl/ConstantPoolAccessor.java
+++ b/parser-core/src/main/java/io/jafar/parser/impl/ConstantPoolAccessor.java
@@ -2,90 +2,55 @@ package io.jafar.parser.impl;
 
 import io.jafar.parser.api.ComplexType;
 import io.jafar.parser.api.ParserContext;
-import io.jafar.parser.internal_api.GenericValueReader;
 import io.jafar.parser.internal_api.MutableConstantPool;
 import io.jafar.parser.internal_api.MutableConstantPools;
-import io.jafar.parser.internal_api.RecordingStream;
 import io.jafar.parser.internal_api.metadata.MetadataClass;
-import io.jafar.parser.internal_api.metadata.MetadataField;
 import java.util.Map;
 import java.util.Objects;
 
-/** Lazy accessor for a constant pool entry that resolves into a Map on-demand. */
-final class ConstantPoolAccessor implements ComplexType {
+/**
+ * Lazy accessor for a constant pool entry that resolves into a Map on-demand.
+ *
+ * <p>Resolution delegates to {@link MutableConstantPool#getAsMap(long)} which maintains a
+ * pool-level cache. This means each unique CP entry is deserialized at most once, regardless of how
+ * many events reference it — turning O(events × CP_fields) redundant deserializations into
+ * O(unique_CP_entries).
+ *
+ * <p><b>API note:</b> This class is {@code public} solely to allow instantiation from ASM-generated
+ * deserializer bytecode in the {@code parser-codegen} module. It is not part of the stable public
+ * API and may change without notice.
+ */
+public final class ConstantPoolAccessor implements ComplexType {
   private final ParserContext context;
   private final long typeId;
   private final long pointer;
 
-  private volatile Map<String, Object> cached;
+  public ConstantPoolAccessor(ParserContext context, MetadataClass type, long pointer) {
+    this(context, type.getId(), pointer);
+  }
 
-  ConstantPoolAccessor(ParserContext context, MetadataClass type, long pointer) {
+  /**
+   * Constructs a new ConstantPoolAccessor using a raw type ID.
+   *
+   * <p>This constructor is used by generated deserializers where the type ID is a compile-time
+   * constant.
+   *
+   * @param context the parser context for this chunk
+   * @param typeId the constant pool type ID
+   * @param pointer the constant pool entry pointer (index)
+   */
+  public ConstantPoolAccessor(ParserContext context, long typeId, long pointer) {
     this.context = context;
-    this.typeId = type.getId();
+    this.typeId = typeId;
     this.pointer = pointer;
   }
 
   @Override
   public Map<String, Object> getValue() {
-    Map<String, Object> v = cached;
-    if (v != null) return v;
-
-    synchronized (this) {
-      v = cached;
-      if (v != null) return v;
-
-      MutableConstantPools pools = (MutableConstantPools) context.getConstantPools();
-      MutableConstantPool pool = pools.getConstantPool(typeId);
-      if (pool == null) return null;
-
-      long offset = pool.getOffset(pointer);
-      if (offset == 0) return null;
-
-      RecordingStream stream = context.get(RecordingStream.class);
-      long pos = stream.position();
-      try {
-        stream.position(offset);
-        MetadataClass clz = context.getMetadataLookup().getClass(typeId);
-
-        // For simple types, the constant pool stores the unwrapped field value directly
-        // We need to read the field value and wrap it in a map with the field name as key
-        if (clz.isSimpleType() && clz.getFields().size() == 1) {
-          MetadataField singleField = clz.getFields().get(0);
-          MetadataClass fieldType = singleField.getType();
-
-          // Recursively unwrap nested simple types to get the actual field type
-          while (fieldType.isSimpleType() && fieldType.getFields().size() == 1) {
-            fieldType = fieldType.getFields().get(0).getType();
-          }
-
-          MapValueBuilder builder = new MapValueBuilder(context);
-          GenericValueReader r = new GenericValueReader(builder);
-
-          // Read the single field value directly (it's stored unwrapped in the CP)
-          builder.onComplexValueStart(null, null, clz);
-          r.readSingleValue(stream, clz, fieldType, singleField.getName());
-          builder.onComplexValueEnd(null, null, clz);
-
-          v = builder.getRoot();
-          cached = v;
-          return v;
-        }
-
-        // For complex types, read as full object
-        MapValueBuilder builder = new MapValueBuilder(context);
-        GenericValueReader r = new GenericValueReader(builder);
-        builder.onComplexValueStart(null, null, clz);
-        r.readValue(stream, clz);
-        builder.onComplexValueEnd(null, null, clz);
-        v = builder.getRoot();
-        cached = v;
-        return v;
-      } catch (Exception e) {
-        throw new RuntimeException(e);
-      } finally {
-        stream.position(pos);
-      }
-    }
+    MutableConstantPools pools = (MutableConstantPools) context.getConstantPools();
+    MutableConstantPool pool = pools.getConstantPool(typeId);
+    if (pool == null) return null;
+    return pool.getAsMap(pointer);
   }
 
   @Override

--- a/parser-core/src/main/java/io/jafar/parser/impl/EventIteratorImpl.java
+++ b/parser-core/src/main/java/io/jafar/parser/impl/EventIteratorImpl.java
@@ -105,6 +105,16 @@ public final class EventIteratorImpl implements EventIterator {
               } catch (InterruptedException e) {
                 // Thread was interrupted during queue.put(END_MARKER)
                 Thread.currentThread().interrupt();
+              } catch (Exception t) {
+                // Catch any unexpected exception to prevent consumer from hanging forever
+                // on queue.take() without receiving the END_MARKER sentinel.
+                // VirtualMachineError (OOM, StackOverflow) deliberately escapes to the JVM.
+                parsingError = new IOException("Unexpected error during parsing", t);
+                try {
+                  queue.put(END_MARKER);
+                } catch (InterruptedException ie) {
+                  Thread.currentThread().interrupt();
+                }
               } finally {
                 // Clean up parser resources
                 try {

--- a/parser-core/src/main/java/io/jafar/parser/impl/UntypedParserContext.java
+++ b/parser-core/src/main/java/io/jafar/parser/impl/UntypedParserContext.java
@@ -74,11 +74,11 @@ public class UntypedParserContext extends ParserContext {
   /**
    * Called when constant pools are ready for processing.
    *
-   * <p>This implementation does nothing as untyped parsing doesn't require active constant pool
-   * management.
+   * <p>Sets the ready flag so that subsequent checkpoint events skip re-processing constant pools
+   * that are already loaded. This prevents unnecessary re-reads in multi-chunk recordings.
    */
   @Override
   public void onConstantPoolsReady() {
-    // do nothing
+    constantPools.setReady();
   }
 }

--- a/parser-core/src/main/java/io/jafar/parser/internal_api/MutableConstantPool.java
+++ b/parser-core/src/main/java/io/jafar/parser/internal_api/MutableConstantPool.java
@@ -6,6 +6,8 @@ import io.jafar.parser.impl.MapValueBuilder;
 import io.jafar.parser.internal_api.collections.LongLongHashMap;
 import io.jafar.parser.internal_api.collections.LongObjectHashMap;
 import io.jafar.parser.internal_api.metadata.MetadataClass;
+import io.jafar.parser.internal_api.metadata.MetadataField;
+import java.util.Map;
 
 /**
  * Mutable implementation of ConstantPool that allows adding offsets and lazy-loading entries.
@@ -15,11 +17,35 @@ import io.jafar.parser.internal_api.metadata.MetadataClass;
  * cached deserialized objects for efficient access.
  */
 public final class MutableConstantPool implements ConstantPool {
-  /** Map of constant pool entry IDs to their file offsets. */
+  /**
+   * Map of constant pool entry IDs to their file offsets.
+   *
+   * <p><b>Thread-safety invariant:</b> written exclusively during checkpoint event processing
+   * (producer thread, before any events are enqueued) and read by both the producer ({@link
+   * #get(long)}) and the consumer ({@link #getAsMap(long)}) threads thereafter. The {@link
+   * java.util.concurrent.ArrayBlockingQueue} hand-off between producer and consumer establishes the
+   * necessary happens-before: all offset writes complete before the first event is dequeued, so the
+   * consumer always sees a fully-populated map without additional synchronization.
+   */
   private final LongLongHashMap offsets;
 
-  /** Map of constant pool entry IDs to their deserialized objects. */
+  /**
+   * Map of constant pool entry IDs to their deserialized objects (typed path).
+   *
+   * <p>Accessed only from the chunk-parser (producer) thread; no synchronization needed.
+   */
   private final LongObjectHashMap<Object> entries;
+
+  /**
+   * Map of constant pool entry IDs to their Map representations (generic/map path).
+   *
+   * <p><b>Design constraint:</b> accessed only from the single consumer (event-iterator) thread. No
+   * synchronization is used; correctness requires that {@link #getAsMap(long)} is never called
+   * concurrently from multiple threads. Callers that introduce parallel consumer threads (e.g.
+   * parallel streams over events) must provide external synchronization or switch to a concurrent
+   * map. Thread-local reader slices provide position isolation from the producer.
+   */
+  private final LongObjectHashMap<Map<String, Object>> mapEntries;
 
   /** The recording stream for reading constant pool data. */
   private final RecordingStream stream;
@@ -37,6 +63,7 @@ public final class MutableConstantPool implements ConstantPool {
   public MutableConstantPool(RecordingStream chunkStream, long typeId, int count) {
     this.offsets = new LongLongHashMap(count);
     this.entries = new LongObjectHashMap<>(count);
+    this.mapEntries = new LongObjectHashMap<>(count);
     this.stream = chunkStream;
     ParserContext context = chunkStream.getContext();
     clazz = context.getMetadataLookup().getClass(typeId);
@@ -44,6 +71,10 @@ public final class MutableConstantPool implements ConstantPool {
 
   /**
    * Gets a constant pool entry by its ID, lazily deserializing if necessary.
+   *
+   * <p>Each thread uses its own thread-local reader slice (sharing the same memory-mapped buffer
+   * but with independent position tracking). Position save/restore handles re-entrancy when reading
+   * a CP entry triggers resolution of another CP type (e.g., string pool lookup).
    *
    * @param id the ID of the constant pool entry
    * @return the deserialized object, or {@code null} if not found
@@ -53,38 +84,116 @@ public final class MutableConstantPool implements ConstantPool {
     if (offset > 0) {
       Object o = entries.get(id);
       if (o == null) {
-        long pos = stream.position();
+        // Thread-local slice: one per thread, reused across calls (no per-call allocation).
+        // Save/restore position for re-entrancy (e.g., reading a CP entry triggers string
+        // pool lookup which re-enters get() on a different pool sharing the same slice).
+        RecordingStream cpStream = stream.threadLocalStreamSlice();
+        long savedPos = cpStream.position();
         try {
-          stream.position(offsets.get(id));
-          // Prefer typed deserialization if available; otherwise fall back to generic map building
-          Object typed = clazz.read(stream);
-          if (typed != null) {
-            o = typed;
-          } else {
-            GenericValueReader r = stream.getContext().get(GenericValueReader.class);
-            if (r != null) {
-              MapValueBuilder builder = (MapValueBuilder) r.getProcessor();
+          cpStream.position(offset);
+          o = clazz.read(cpStream);
+          if (o == null) {
+            // For String constant pool entries, read the string directly.
+            // Using the generic MapValueBuilder path would wrap the string in a Map,
+            // breaking ParsingUtils.readUTF8() which expects stringPool.get() to return
+            // a String (checked via instanceof String).
+            // Note: in JFR, String is the only primitive type stored in a constant pool.
+            if (clazz.isPrimitive() && "java.lang.String".equals(clazz.getName())) {
+              try {
+                o = cpStream.readUTF8();
+              } catch (java.io.IOException ioe) {
+                throw new RuntimeException(ioe);
+              }
+            } else {
+              MapValueBuilder builder = new MapValueBuilder(stream.getContext());
+              GenericValueReader r = new GenericValueReader(builder);
               builder.onComplexValueStart(null, null, clazz);
               try {
-                r.readValue(stream, clazz);
+                r.readValue(cpStream, clazz);
               } catch (java.io.IOException ioe) {
                 throw new RuntimeException(ioe);
               }
               builder.onComplexValueEnd(null, null, clazz);
               o = builder.getRoot();
             }
-            // If GenericValueReader is not available, o remains null
           }
           if (o != null) {
             entries.put(id, o);
           }
         } finally {
-          stream.position(pos);
+          cpStream.position(savedPos);
         }
       }
       return o;
     }
     return null;
+  }
+
+  /**
+   * Gets a constant pool entry as a {@code Map<String, Object>} representation, using a pool-level
+   * cache so that each entry is deserialized at most once regardless of how many events reference
+   * it.
+   *
+   * <p>This is the primary method for generic (map-based) constant pool resolution. Unlike per-
+   * accessor deserialization, the result is shared across all accessors pointing to the same entry,
+   * eliminating O(events) redundant deserializations.
+   *
+   * @param id the ID of the constant pool entry
+   * @return the map representation, or {@code null} if not found
+   */
+  public Map<String, Object> getAsMap(long id) {
+    long offset = offsets.get(id);
+    if (offset <= 0) return null;
+
+    Map<String, Object> v = mapEntries.get(id);
+    if (v != null) return v;
+
+    RecordingStream cpStream = stream.threadLocalStreamSlice();
+    long savedPos = cpStream.position();
+    try {
+      cpStream.position(offset);
+
+      // For simple types (e.g. String CP), the pool stores the unwrapped field value directly.
+      // Read it and wrap in a single-entry map keyed by the field name.
+      if (clazz.isSimpleType() && clazz.getFields().size() == 1) {
+        MetadataField singleField = clazz.getFields().get(0);
+        MetadataClass fieldType = singleField.getType();
+        // Unwrap nested single-field simple types (depth-guarded against malformed metadata).
+        int depth = 0;
+        while (fieldType.isSimpleType() && fieldType.getFields().size() == 1) {
+          if (++depth > 10) break;
+          fieldType = fieldType.getFields().get(0).getType();
+        }
+        MapValueBuilder builder = new MapValueBuilder(stream.getContext());
+        GenericValueReader r = new GenericValueReader(builder);
+        builder.onComplexValueStart(null, null, clazz);
+        try {
+          r.readSingleValue(cpStream, clazz, fieldType, singleField.getName());
+        } catch (java.io.IOException ioe) {
+          throw new RuntimeException(ioe);
+        }
+        builder.onComplexValueEnd(null, null, clazz);
+        v = builder.getRoot();
+      } else {
+        // Complex type: full object deserialization
+        MapValueBuilder builder = new MapValueBuilder(stream.getContext());
+        GenericValueReader r = new GenericValueReader(builder);
+        builder.onComplexValueStart(null, null, clazz);
+        try {
+          r.readValue(cpStream, clazz);
+        } catch (java.io.IOException ioe) {
+          throw new RuntimeException(ioe);
+        }
+        builder.onComplexValueEnd(null, null, clazz);
+        v = builder.getRoot();
+      }
+      if (v != null) {
+        mapEntries.put(id, v);
+      }
+      return v;
+    } finally {
+      cpStream.position(savedPos);
+    }
   }
 
   @Override

--- a/parser-core/src/main/java/io/jafar/parser/internal_api/MutableConstantPools.java
+++ b/parser-core/src/main/java/io/jafar/parser/internal_api/MutableConstantPools.java
@@ -16,8 +16,13 @@ public final class MutableConstantPools implements ConstantPools {
   /** Map of type IDs to their corresponding constant pool instances. */
   private final LongObjectHashMap<MutableConstantPool> poolMap = new LongObjectHashMap<>();
 
-  /** Flag indicating whether all constant pools are ready for use. */
-  private boolean ready = false;
+  /**
+   * Flag indicating whether all constant pools are ready for use.
+   *
+   * <p>Written by the producer thread (via {@link #setReady()}) and read by both the producer and
+   * the consumer thread; must be volatile to ensure visibility across threads.
+   */
+  private volatile boolean ready = false;
 
   /** Constructs a new MutableConstantPools instance. */
   public MutableConstantPools() {}

--- a/parser-core/src/main/java/io/jafar/parser/internal_api/RecordingStream.java
+++ b/parser-core/src/main/java/io/jafar/parser/internal_api/RecordingStream.java
@@ -22,6 +22,20 @@ public final class RecordingStream implements AutoCloseable {
   private long mark = -1;
 
   /**
+   * Thread-local cache of {@link RecordingStream} slices for constant pool resolution.
+   *
+   * <p>Each entry wraps a {@link RecordingStreamReader} that shares the same underlying
+   * memory-mapped buffer but has independent position tracking. Lazy-initialized to avoid
+   * allocating a ThreadLocal on short-lived wrapper instances that never call {@link
+   * #threadLocalStreamSlice()}.
+   *
+   * <p><b>Lifecycle:</b> each participating thread's entry is removed when {@link #close()} is
+   * called from that thread. Entries for other threads are removed when those threads exit. In
+   * practice, {@link RecordingStream} instances are chunk-scoped, so exposure is bounded.
+   */
+  private volatile ThreadLocal<RecordingStream> threadLocalStreamCache;
+
+  /**
    * Constructs a new RecordingStream from a file path.
    *
    * @param path the path to the JFR recording file
@@ -51,9 +65,56 @@ public final class RecordingStream implements AutoCloseable {
    * @param context the parser context to use
    */
   public RecordingStream(RecordingStreamReader reader, ParserContext context) {
+    this(reader, context, true);
+  }
+
+  /**
+   * Constructs a new RecordingStream with optional context registration.
+   *
+   * <p>When {@code register} is {@code false}, the stream is not registered in the context. This is
+   * used for creating temporary streams for thread-safe constant pool resolution.
+   *
+   * @param reader the reader for the recording data
+   * @param context the parser context to use
+   * @param register whether to register this stream in the context
+   */
+  public RecordingStream(RecordingStreamReader reader, ParserContext context, boolean register) {
     this.reader = reader;
     this.context = context;
-    this.context.put(RecordingStream.class, this);
+    if (register) {
+      this.context.put(RecordingStream.class, this);
+    }
+  }
+
+  /**
+   * Returns a thread-local {@link RecordingStream} slice, creating one lazily per thread.
+   *
+   * <p>Each slice shares the same underlying memory-mapped buffer but has independent position
+   * tracking. Position save/restore can be performed on the returned stream directly. Eliminates
+   * per-resolution wrapper allocation compared to {@code new RecordingStream(slice, ...)}.
+   *
+   * <p>Re-entrancy (e.g. reading a CP entry that triggers a string pool lookup) is handled by the
+   * caller via explicit position save/restore before and after each use.
+   *
+   * @return a reusable stream slice for the current thread
+   */
+  public RecordingStream threadLocalStreamSlice() {
+    ThreadLocal<RecordingStream> tl = threadLocalStreamCache;
+    if (tl == null) {
+      synchronized (this) {
+        tl = threadLocalStreamCache;
+        if (tl == null) {
+          tl = new ThreadLocal<>();
+          threadLocalStreamCache = tl;
+        }
+      }
+    }
+    RecordingStream s = tl.get();
+    if (s == null) {
+      s = new RecordingStream(reader.slice(0, reader.length()), context, false);
+      tl.set(s);
+    }
+    return s;
   }
 
   /**
@@ -206,6 +267,12 @@ public final class RecordingStream implements AutoCloseable {
 
   @Override
   public void close() {
+    // Remove the current thread's slice from the cache to avoid retaining references after close.
+    // Entries for other threads are not removable cross-thread; they are cleared when those
+    // threads exit or when the GC processes their ThreadLocalMap entries.
+    if (threadLocalStreamCache != null) {
+      threadLocalStreamCache.remove();
+    }
     try {
       reader.close();
     } catch (IOException ignored) {


### PR DESCRIPTION
Fixes #90

## Root cause

`UntypedCodeGenerator` stored the raw `long` CP pointer in generated event deserializers instead of creating a `ConstantPoolAccessor`. This meant every CP-backed field (e.g. `eventThread`, `stackTrace`, `Class`) arrived in the event value map as a raw `Long` — or `null` after auto-unboxing — rather than as a lazy `ComplexType` that resolves on demand.

## Fix

Five coordinated changes, working together:

1. **`UntypedCodeGenerator`** — emits `new ConstantPoolAccessor(ctx, typeId, pointer)` for CP-typed fields instead of the raw `long` pointer.

2. **`ConstantPoolAccessor`** — lazy `ComplexType` implementation; `getValue()` delegates to `MutableConstantPool.getAsMap(pointer)`. Made `public` so ASM-generated bytecode can instantiate it directly.

3. **`MutableConstantPool.getAsMap()`** — new pool-level cache (`LongObjectHashMap<Map<String,Object>> mapEntries`) that deserializes each CP entry at most once, regardless of how many events reference it (O(unique entries) instead of O(events × CP fields)).

4. **`RecordingStream.threadLocalStreamSlice()`** — returns a per-thread `RecordingStream` wrapping an independent position cursor over the same memory-mapped buffer. Both `get()` and `getAsMap()` use this for safe, allocation-free CP resolution.

5. **`UntypedParserContext.onConstantPoolsReady()`** — was a no-op; now calls `constantPools.setReady()` so multi-chunk recordings don't re-process checkpoint events unnecessarily.

## Architecture

```mermaid
sequenceDiagram
    participant P as Producer thread<br/>(parser)
    participant Q as ArrayBlockingQueue
    participant C as Consumer thread<br/>(EventIterator)
    participant A as ConstantPoolAccessor
    participant M as MutableConstantPool
    participant S as Thread-local stream slice

    P->>P: parse event, read CP pointer
    P->>P: new ConstantPoolAccessor(ctx, typeId, ptr)
    P->>Q: put(JafarRecordedEvent) [blocks if full]
    Q-->>C: take() → JafarRecordedEvent
    note over Q: happens-before: all CP offsets<br/>written before event dequeued
    C->>A: event.value().get("eventThread")
    C->>A: ComplexType.getValue()
    A->>M: getAsMap(pointer)
    M->>M: mapEntries.get(id) → cache hit?
    alt cache miss
        M->>S: threadLocalStreamSlice()
        S-->>M: per-thread RecordingStream
        M->>S: position(offset), read & deserialize
        M->>M: mapEntries.put(id, map)
    end
    M-->>A: Map<String, Object>
    A-->>C: resolved map
```

## Test plan

- [x] `testCpBackedFieldsAreNotNull` — focused regression test: first event's `eventThread` and `stackTrace` fields must be non-null `ComplexType` instances whose `.getValue()` returns a populated map
- [x] `testIteratorConstantPoolFieldsAreResolvable` — every CP-typed field across all 100 events resolves to a non-empty map
- [x] `testIteratorFieldValuesMatchCallback` — deep recursive equality comparison between callback-based and iterator-based event values (handles `Object[]` frames by content)
- [x] `testIteratorMultiChunkCpResolution` — two-chunk synthetic recording; 40 total events; all CP fields resolve across chunk boundaries
- [x] `testIteratorConsumesAllEvents`, `testIteratorEarlyTermination`, `testIteratorContractCompliance` — iterator contract and backpressure
- [x] `testIteratorWithCustomBufferSize` / `testIteratorInvalidBufferSize` — buffer size validation
- [x] All tests use a `@BeforeAll`-generated synthetic JFR (no large test-ap.jfr dependency)

🤖 Generated with [Claude Code](https://claude.ai/code)