### PR TITLE
Bundle jfr2pprof into the published jafar-tools artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -268,7 +268,7 @@ jobs:
           # Bump -latest wrappers to the next snapshot version
           sed -i.bak "s|//DEPS io.btrace:jafar-shell:.*|//DEPS io.btrace:jafar-shell:$NEXT_SNAPSHOT|g" jafar-shell-latest.java
           sed -i.bak "s|//DEPS io.btrace:jfr-mcp:.*|//DEPS io.btrace:jfr-mcp:$NEXT_SNAPSHOT|g" jfr-mcp-latest.java
-          sed -i.bak "s|//DEPS io.btrace:jafar-tools:.*|//DEPS io.btrace:jafar-tools:$NEXT_SNAPSHOT|g" jfr2pprof-latest.java
+          sed -i.bak "s|//DEPS io.btrace:jafar-tools:.*|//DEPS io.btrace:jafar-tools:$NEXT_SNAPSHOT|g" jafar-tools-latest.java
 
           # Clean up backup files
           rm -f *.bak
@@ -294,7 +294,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
           # Stage all modified catalog files
-          git add jbang-catalog.json jafar-shell.java jafar-shell-latest.java jfr-mcp-latest.java jfr2pprof-latest.java
+          git add jbang-catalog.json jafar-shell.java jafar-shell-latest.java jfr-mcp-latest.java jafar-tools-latest.java
 
           if git commit -m "Release $VERSION; bump snapshots to next version"; then
             git push || echo "⚠️ Push failed - update catalog manually at https://github.com/btraceio/jbang-catalog"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -268,6 +268,7 @@ jobs:
           # Bump -latest wrappers to the next snapshot version
           sed -i.bak "s|//DEPS io.btrace:jafar-shell:.*|//DEPS io.btrace:jafar-shell:$NEXT_SNAPSHOT|g" jafar-shell-latest.java
           sed -i.bak "s|//DEPS io.btrace:jfr-mcp:.*|//DEPS io.btrace:jfr-mcp:$NEXT_SNAPSHOT|g" jfr-mcp-latest.java
+          sed -i.bak "s|//DEPS io.btrace:jafar-tools:.*|//DEPS io.btrace:jafar-tools:$NEXT_SNAPSHOT|g" jfr2pprof-latest.java
 
           # Clean up backup files
           rm -f *.bak
@@ -293,7 +294,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
           # Stage all modified catalog files
-          git add jbang-catalog.json jafar-shell.java jafar-shell-latest.java jfr-mcp-latest.java
+          git add jbang-catalog.json jafar-shell.java jafar-shell-latest.java jfr-mcp-latest.java jfr2pprof-latest.java
 
           if git commit -m "Release $VERSION; bump snapshots to next version"; then
             git push || echo "⚠️ Push failed - update catalog manually at https://github.com/btraceio/jbang-catalog"

--- a/.github/workflows/sync-jbang-catalog.yml
+++ b/.github/workflows/sync-jbang-catalog.yml
@@ -186,6 +186,7 @@ jobs:
           # Bump -latest wrappers to the next snapshot version
           sed -i.bak "s|//DEPS io.btrace:jafar-shell:.*|//DEPS io.btrace:jafar-shell:$NEXT_SNAPSHOT|g" jafar-shell-latest.java
           sed -i.bak "s|//DEPS io.btrace:jfr-mcp:.*|//DEPS io.btrace:jfr-mcp:$NEXT_SNAPSHOT|g" jfr-mcp-latest.java
+          sed -i.bak "s|//DEPS io.btrace:jafar-tools:.*|//DEPS io.btrace:jafar-tools:$NEXT_SNAPSHOT|g" jfr2pprof-latest.java
 
           # Clean up backup files
           rm -f *.bak
@@ -205,7 +206,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
           # Stage all modified catalog files
-          git add jbang-catalog.json jafar-shell.java jafar-shell-latest.java jfr-mcp-latest.java
+          git add jbang-catalog.json jafar-shell.java jafar-shell-latest.java jfr-mcp-latest.java jfr2pprof-latest.java
 
           if git commit -m "Update jafar-shell and jfr-mcp to $VERSION; bump snapshots"; then
             if git push; then

--- a/.github/workflows/sync-jbang-catalog.yml
+++ b/.github/workflows/sync-jbang-catalog.yml
@@ -186,7 +186,7 @@ jobs:
           # Bump -latest wrappers to the next snapshot version
           sed -i.bak "s|//DEPS io.btrace:jafar-shell:.*|//DEPS io.btrace:jafar-shell:$NEXT_SNAPSHOT|g" jafar-shell-latest.java
           sed -i.bak "s|//DEPS io.btrace:jfr-mcp:.*|//DEPS io.btrace:jfr-mcp:$NEXT_SNAPSHOT|g" jfr-mcp-latest.java
-          sed -i.bak "s|//DEPS io.btrace:jafar-tools:.*|//DEPS io.btrace:jafar-tools:$NEXT_SNAPSHOT|g" jfr2pprof-latest.java
+          sed -i.bak "s|//DEPS io.btrace:jafar-tools:.*|//DEPS io.btrace:jafar-tools:$NEXT_SNAPSHOT|g" jafar-tools-latest.java
 
           # Clean up backup files
           rm -f *.bak
@@ -206,7 +206,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
           # Stage all modified catalog files
-          git add jbang-catalog.json jafar-shell.java jafar-shell-latest.java jfr-mcp-latest.java jfr2pprof-latest.java
+          git add jbang-catalog.json jafar-shell.java jafar-shell-latest.java jfr-mcp-latest.java jafar-tools-latest.java
 
           if git commit -m "Update jafar-shell and jfr-mcp to $VERSION; bump snapshots"; then
             if git push; then

--- a/jfr2pprof/build.gradle
+++ b/jfr2pprof/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 
@@ -15,7 +15,7 @@ repositories {
 }
 
 dependencies {
-    implementation project(':parser')
+    implementation project(':parser-core')
     implementation 'org.snakeyaml:snakeyaml-engine:2.9'
     implementation 'org.slf4j:slf4j-api:2.0.16'
     runtimeOnly   'ch.qos.logback:logback-classic:1.5.18'
@@ -27,7 +27,17 @@ dependencies {
     testImplementation project(':pprof-shell')
 }
 
+// Compile and run tests with Java 25 (pprof-shell test dependency requires it); main sources target 21
+def j25CompilerProvider = javaToolchains.compilerFor { languageVersion = JavaLanguageVersion.of(25) }
+tasks.named('compileTestJava').configure { JavaCompile t ->
+    t.javaCompiler.set(j25CompilerProvider)
+    t.options.release.set(25)
+}
+
+def j25LauncherProvider = javaToolchains.launcherFor { languageVersion = JavaLanguageVersion.of(25) }
+
 test {
+    javaLauncher.set(j25LauncherProvider)
     useJUnitPlatform()
 }
 

--- a/tools/build.gradle
+++ b/tools/build.gradle
@@ -90,21 +90,23 @@ group = 'io.btrace'
 version = component_version
 description = 'JFR (Java Flight Recorder) manipulation tools'
 
-// Shadow JAR: embed internal parser-core module
+// Shadow JAR: embed internal parser-core module plus the runtime deps the
+// bundled Main-Class launcher needs to actually run standalone (java -jar).
 shadowJar {
     archiveBaseName = libraryName
     archiveVersion = component_version
     archiveClassifier.set('all')
     configurations = [project.configurations.runtimeClasspath, project.configurations.shadedInclude]
-    // Only include internal project modules, not external dependencies
     dependencies {
         include(project(':parser-core'))
         include(project(':jfr2pprof'))
         include(dependency('org.snakeyaml:snakeyaml-engine'))
+        include(dependency('org.slf4j:slf4j-api'))
+        include(dependency('org.slf4j:slf4j-simple'))
     }
     // parser-core is a Multi-Release JAR
     manifest {
-        attributes('Multi-Release': 'true')
+        attributes('Multi-Release': 'true', 'Main-Class': 'io.jafar.tools.Main')
     }
 }
 

--- a/tools/build.gradle
+++ b/tools/build.gradle
@@ -40,8 +40,19 @@ tasks.named('compileTestJava').configure { JavaCompile t ->
 
 def j21LauncherProvider = javaToolchains.launcherFor { languageVersion = JavaLanguageVersion.of(21) }
 
+configurations {
+    // jfr2pprof targets a newer JVM version than this module's main sourceSet (Java 8),
+    // so it can't participate in the JVM-version-matched compile/runtime classpaths.
+    // Resolve it separately and shade its classes into the shadow JAR instead.
+    shadedInclude
+}
+
 dependencies {
     implementation project(':parser-core')
+    shadedInclude(project(':jfr2pprof')) { transitive = false }
+    // snakeyaml-engine is only used internally by jfr2pprof's MappingLoader; shade it in
+    // rather than exposing it as a published dependency.
+    shadedInclude 'org.snakeyaml:snakeyaml-engine:2.9'
     // Re-declare external deps from parser-core so they appear in the published POM
     // (parser-core is shaded into the shadow JAR and removed from the POM)
     runtimeOnly 'org.slf4j:slf4j-api:2.0.5'
@@ -84,9 +95,12 @@ shadowJar {
     archiveBaseName = libraryName
     archiveVersion = component_version
     archiveClassifier.set('all')
-    // Only include internal project module, not external dependencies
+    configurations = [project.configurations.runtimeClasspath, project.configurations.shadedInclude]
+    // Only include internal project modules, not external dependencies
     dependencies {
         include(project(':parser-core'))
+        include(project(':jfr2pprof'))
+        include(dependency('org.snakeyaml:snakeyaml-engine'))
     }
     // parser-core is a Multi-Release JAR
     manifest {
@@ -116,7 +130,7 @@ afterEvaluate {
                     if (deps) {
                         deps.each { depsNode ->
                             depsNode.children().removeAll { dep ->
-                                dep.artifactId.text() == 'jafar-parser-core'
+                                dep.artifactId.text() == 'jafar-parser-core' || dep.artifactId.text() == 'jfr2pprof'
                             }
                         }
                     }

--- a/tools/src/main/java/io/jafar/tools/Main.java
+++ b/tools/src/main/java/io/jafar/tools/Main.java
@@ -1,0 +1,58 @@
+package io.jafar.tools;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+/**
+ * Dispatches to the individual command-line tools bundled in jafar-tools.
+ *
+ * <p>Tools are invoked via reflection because they may be compiled for a newer bytecode target than
+ * this module's own Java 8 baseline (e.g. jfr2pprof), so this class must not reference their types
+ * directly at compile time.
+ */
+public final class Main {
+
+  private Main() {}
+
+  public static void main(String[] args) throws Exception {
+    if (args.length == 0) {
+      usage();
+      System.exit(1);
+    }
+
+    String tool = args[0];
+    String[] rest = Arrays.copyOfRange(args, 1, args.length);
+
+    switch (tool) {
+      case "jfr2pprof":
+        invoke("io.jafar.jfr2pprof.Main", rest);
+        break;
+      case "scrub":
+        ScrubberMain.main(rest);
+        break;
+      default:
+        System.err.println("Unknown tool: " + tool);
+        usage();
+        System.exit(1);
+    }
+  }
+
+  private static void invoke(String mainClassName, String[] args) {
+    try {
+      Method main = Class.forName(mainClassName).getMethod("main", String[].class);
+      main.invoke(null, (Object) args);
+    } catch (InvocationTargetException e) {
+      throw new IllegalStateException(mainClassName + " failed", e.getCause());
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException("Failed to launch " + mainClassName, e);
+    }
+  }
+
+  private static void usage() {
+    System.err.println("Usage: <tool> [args...]");
+    System.err.println("Available tools:");
+    System.err.println("  jfr2pprof   Convert a JFR recording to a pprof profile");
+    System.err.println("  scrub       Redact sensitive fields from a JFR recording");
+  }
+}

--- a/tools/src/main/java/io/jafar/tools/ScrubberMain.java
+++ b/tools/src/main/java/io/jafar/tools/ScrubberMain.java
@@ -1,0 +1,70 @@
+package io.jafar.tools;
+
+import io.jafar.tools.Scrubber.ScrubField;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+/** Command-line entry point for {@link Scrubber}. */
+public final class ScrubberMain {
+
+  private ScrubberMain() {}
+
+  public static void main(String[] args) throws Exception {
+    Path input = null;
+    Path output = null;
+    List<String[]> scrubFields = new ArrayList<>();
+
+    for (int i = 0; i < args.length; i++) {
+      switch (args[i]) {
+        case "--input":
+          input = Paths.get(args[++i]);
+          break;
+        case "--output":
+          output = Paths.get(args[++i]);
+          break;
+        case "--scrub-field":
+          scrubFields.add(splitTypeField(args[++i]));
+          break;
+        default:
+          usage();
+          System.exit(1);
+          return;
+      }
+    }
+
+    if (input == null || output == null || scrubFields.isEmpty()) {
+      usage();
+      System.exit(1);
+      return;
+    }
+
+    List<String[]> fields = scrubFields;
+    Scrubber.scrubFile(
+        input,
+        output,
+        type -> {
+          for (String[] field : fields) {
+            if (field[0].equals(type)) {
+              return new ScrubField(null, field[1], null);
+            }
+          }
+          return null;
+        });
+  }
+
+  private static String[] splitTypeField(String spec) {
+    int dot = spec.lastIndexOf('.');
+    if (dot < 0) {
+      throw new IllegalArgumentException("--scrub-field must be <Type>.<field>, got: " + spec);
+    }
+    return new String[] {spec.substring(0, dot), spec.substring(dot + 1)};
+  }
+
+  private static void usage() {
+    System.err.println(
+        "Usage: scrub --input <recording.jfr> --output <scrubbed.jfr>"
+            + " --scrub-field <Type>.<field> [--scrub-field <Type>.<field> ...]");
+  }
+}


### PR DESCRIPTION
## Summary
- Shade jfr2pprof's classes (and its `snakeyaml-engine` dependency) into `jafar-tools`' shadow JAR, resolving them via a dedicated configuration to avoid the JVM-version variant-matching conflict between the two modules' toolchains.

- Drop jfr2pprof's main toolchain from Java 25 to 21 (its records/arrow-switch syntax only requires 16+, and its runtime dependency on `parser`/`parser-core` only needs Java 8) so it no longer imposes an unnecessarily high JVM requirement; test compilation/execution stays on Java 25 since the test suite depends on `pprof-shell`.

- Add a unified `io.jafar.tools.Main` dispatcher (`java -jar jafar-tools-*-all.jar <tool> [args...]`) so a single JBang launcher can cover every CLI tool bundled in `jafar-tools`, rather than needing a new jbang-catalog launcher per tool. It dispatches to `jfr2pprof` via reflection (its classes are Java 21 bytecode, unreadable by the module's Java 8 `compileJava`), and to a new `scrub` sub-command backed by a new `ScrubberMain` CLI wrapper around the existing `Scrubber` API.

- Bundle `slf4j-api`/`slf4j-simple` into the shadow JAR too, since the dispatcher jar is meant to run standalone (`java -jar`) — without them the launcher failed with `NoClassDefFoundError` the moment either sub-tool touched the parser. The published POM still declares them as regular runtime dependencies.

- Verified the generated `jafar-tools` POM stays clean (only `slf4j-api`/`slf4j-simple` remain as external runtime deps; `jfr2pprof`, `parser-core`, and `snakeyaml-engine` are embedded, not declared).

- Wire the jbang-catalog sync workflows (`release.yml`, `sync-jbang-catalog.yml`) to bump a unified `jafar-tools-latest.java` wrapper alongside the other `-latest` wrappers. Companion PR to add the wrapper itself: btraceio/jbang-catalog#1. A stable `jafar-tools` alias will follow once a release actually contains this bundled feature.

## Test plan
- [x] `./gradlew :jfr2pprof:test` passes
- [x] `./gradlew :tools:test` passes
- [x] `./gradlew :tools:shadowJar` — verified `io/jafar/jfr2pprof/**`, `org/snakeyaml/**`, and `org/slf4j/**` classes are present in the shaded jar, with `Main-Class: io.jafar.tools.Main`
- [x] `./gradlew :tools:generatePomFileForMavenPublication` — verified no leaked `jfr2pprof`/`jafar-parser-core`/`snakeyaml-engine` POM dependency entries
- [x] `java -jar jafar-tools-*-all.jar jfr2pprof --help` and `... scrub` — dispatcher correctly delegates to both sub-tools
- [x] `java -jar jafar-tools-*-all.jar scrub --input <recording.jfr> --output <out.jfr> --scrub-field jdk.InitialSystemProperty.value` — end-to-end scrub against a real JFR file
- [x] Published `jafar-tools` to mavenLocal and ran `jbang jafar-tools-latest.java jfr2pprof --help` / `... scrub` (pointed at mavenLocal) — correctly resolved and dispatched