### PR TITLE
Update JBang docs for Java 26+ auto-provisioning

### DIFF
--- a/doc/jbang/JFRShellUsage.md
+++ b/doc/jbang/JFRShellUsage.md
@@ -212,7 +212,7 @@ Control JBang behavior with environment variables:
 
 ```bash
 # Use specific Java version
-export JAVA_HOME=/path/to/java-21
+export JAVA_HOME=/path/to/java-26
 jbang jfr-shell@btraceio recording.jfr
 
 # Enable debug output
@@ -267,7 +267,7 @@ Use in CI/CD pipelines:
 
 **Problem**: `UnsupportedClassVersionError` or Java version errors
 
-**Solution**: JBang automatically downloads Java 21+ if needed. Force a fresh install:
+**Solution**: JBang automatically downloads Java 26+ if needed. Force a fresh install:
 
 ```bash
 jbang --fresh jfr-shell@btraceio recording.jfr

--- a/doc/mcp/JBANGCatalogSetup.md
+++ b/doc/mcp/JBANGCatalogSetup.md
@@ -15,7 +15,7 @@ The following files need to be added to https://github.com/btraceio/jbang-catalo
 ///usr/bin/env jbang "$0" "$@" ; exit $?
 //DEPS io.btrace:jfr-mcp:0.10.0
 //DESCRIPTION Jafar MCP Server - AI-assisted JFR analysis via Model Context Protocol (Stable)
-//JAVA 21+
+//JAVA 26+
 
 /**
  * Jafar MCP Server launcher (stable releases).
@@ -53,7 +53,7 @@ public class jfr_mcp {
 //DEPS io.btrace:jfr-mcp:main-SNAPSHOT
 //REPOS mavencentral,ossrh-snapshots=https://s01.oss.sonatype.org/content/repositories/snapshots
 //DESCRIPTION Jafar MCP Server - AI-assisted JFR analysis (Development Snapshots)
-//JAVA 21+
+//JAVA 26+
 
 /**
  * Jafar MCP Server launcher (development snapshots).

--- a/doc/mcp/JBANGUsage.md
+++ b/doc/mcp/JBANGUsage.md
@@ -231,7 +231,7 @@ Control server behavior:
 MCP_PORT=8080 jbang jfr-mcp@btraceio
 
 # Use specific Java version
-export JAVA_HOME=/path/to/java-21
+export JAVA_HOME=/path/to/java-26
 jbang jfr-mcp@btraceio
 
 # Enable JBang debug output
@@ -312,7 +312,7 @@ netstat -ano | findstr :3000
 
 **Problem**: `UnsupportedClassVersionError` or Java version errors
 
-**Solution**: JBang automatically downloads Java 21+ if needed. Force a fresh install:
+**Solution**: JBang automatically downloads Java 26+ if needed. Force a fresh install:
 
 ```bash
 jbang --fresh jfr-mcp@btraceio


### PR DESCRIPTION
## Summary

- Updates `doc/mcp/JBANGCatalogSetup.md`, `doc/mcp/JBANGUsage.md`, and `doc/jbang/JFRShellUsage.md` to reflect the bumped `//JAVA` requirement in the companion `btraceio/jbang-catalog` PR: the `jafar-shell`, `jfr-mcp`, and `jafar-tools` JBang launchers now declare `//JAVA 26+`, so `jbang` auto-downloads JDK 26 instead of relying on a pre-installed JDK.
- Bumps the `//JAVA 21+` template snippets, `JAVA_HOME=/path/to/java-21` examples, and the "JBang automatically downloads Java 21+" troubleshooting text to 26.

This is a docs-only change; no build/toolchain changes here (the Gradle toolchains for jafar-shell/jfr-mcp stay on `JavaLanguageVersion.of(25)` — Java 26 runtime is backward-compatible with Java 25 bytecode).

Companion PR: btraceio/jbang-catalog (same branch name) updates the actual launcher scripts.

## Test plan

- [x] Reviewed diff for consistency with the jbang-catalog launcher changes
- [ ] N/A — docs only, no build/test impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPXj7yQsvKT8ZhqCQmcTyv

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPXj7yQsvKT8ZhqCQmcTyv)_