### PR TITLE
Fit the Go benchmark job to the real recording corpus

### DIFF
--- a/.github/workflows/go-parser-bench.yml
+++ b/.github/workflows/go-parser-bench.yml
@@ -55,18 +55,24 @@ permissions:
   contents: read
 
 env:
-  # The recordings get_resources.sh downloads are of unknown size on a first
-  # run, so the scheduled and push defaults are deliberately modest. Raise them
-  # through workflow_dispatch once the runtime is known.
-  BENCHTIME: ${{ inputs.benchtime || '3x' }}
-  BENCHCOUNT: ${{ inputs.count || '3' }}
+  # inputs.* is empty for schedule and push, so these fall back to the cheap
+  # settings while a workflow_dispatch run picks up the richer input defaults
+  # below. The recordings are large - the corpus is ~2 GB, one file of it 1.8 GB
+  # - and every benchmark iteration parses a whole file, so an unattended run
+  # takes one sample per benchmark. Allocation counts are deterministic and stay
+  # exact at one iteration, which is the signal worth tracking over time; timing
+  # at one sample is indicative, so raise these by hand when timing is the point.
+  BENCHTIME: ${{ inputs.benchtime || '1x' }}
+  BENCHCOUNT: ${{ inputs.count || '1' }}
   BENCHPATTERN: ${{ inputs.pattern || '.' }}
 
 jobs:
   benchmark:
     name: Benchmark
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    # A full workflow_dispatch sweep over the corpus at 3x/3 is roughly 40
+    # minutes; the unattended run is a few minutes.
+    timeout-minutes: 90
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -120,7 +126,7 @@ jobs:
             -benchtime "$BENCHTIME" \
             -count "$BENCHCOUNT" \
             -benchmem \
-            -timeout 55m \
+            -timeout 80m \
             ./... 2>&1 | tee ../bench-current.txt
 
       - name: Benchmark the baseline
@@ -139,7 +145,7 @@ jobs:
             -benchtime "$BENCHTIME" \
             -count "$BENCHCOUNT" \
             -benchmem \
-            -timeout 55m \
+            -timeout 80m \
             ./... 2>&1 | tee "$GITHUB_WORKSPACE/bench-baseline.txt"
 
       - name: Compare against the baseline

--- a/go-parser/README.md
+++ b/go-parser/README.md
@@ -137,6 +137,34 @@ are only valid until the handler returns. Leave it off if you keep events, and
 it is off by default. Values resolved from a constant pool are cached in their
 pool and stay valid either way.
 
+### On large recordings
+
+Measured on the benchmark corpus `./get_resources.sh` downloads, on a GitHub
+`ubuntu-latest` runner:
+
+| Recording | Size | Events | Decode one type, two fields, `ReuseValues` |
+|---|---:|---:|---|
+| `test-ap.jfr` | 179 MB | 2 908 299 | 1.94 s, 668 ns/event, 45 MB, 2.9 M allocs |
+| `test-jfr.jfr` | 1.78 GB | 10 673 057 | 13.95 s, 1307 ns/event, 422 MB, 21.7 M allocs |
+
+Per-event cost stays flat as the recording grows, which is the property that
+matters. One thing does not, and it is worth knowing before you write a
+consumer:
+
+**Resolving a constant pool reference on every event materialises the whole
+pool.** Entries are cached for the life of the chunk, so reading one stack frame
+per event pulls the entire stack trace, frame, method and symbol graph into
+memory and keeps it there. On `tck-test.jfr` (14 202 events) that costs 21 ms
+and 153 k allocations; on `test-jfr.jfr` (10.7 M events) the same one-line
+access costs **69 s and 494 M allocations**, because the pool it is filling is
+three orders of magnitude larger. The caching is what makes the common case
+fast - a stack trace shared by ten thousand events is decoded once - but it
+scales with the pool, not with the work you asked for.
+
+If you only need a few stack traces out of many events, filter the events down
+first (`TypeFilter`, or a predicate in the handler) and resolve only what
+survives.
+
 Two other things matter more than they look:
 
 * **Filter early.** `TypeFilter` skips an event before it is decoded. On the

--- a/go-parser/jfr/bench_test.go
+++ b/go-parser/jfr/bench_test.go
@@ -153,6 +153,30 @@ func (r *benchRecording) profile() error {
 	return nil
 }
 
+// largeRecordingBytes is the size above which the constant-pool resolution
+// benchmarks skip a recording.
+//
+// Resolving one stack frame per event forces the whole stack trace pool into
+// memory, and the pool is cached for the life of the chunk, so the cost grows
+// with the recording rather than with the work asked of it: on a 1.8 GB
+// recording BenchmarkResolveTopFrame measured 69 s, 69 GB and 494 M allocations
+// for a single iteration. That is a real property of the parser worth knowing,
+// but it is not a routine regression check - it swamps every other benchmark in
+// the suite. Point the suite at one such recording deliberately
+// (JAFAR_BENCH_JFR) when that is what you want to measure.
+const largeRecordingBytes = 256 << 20
+
+// skipIfLarge skips a constant-pool resolution benchmark on a recording big
+// enough for it to dominate the run.
+func (r *benchRecording) skipIfLarge(b *testing.B) bool {
+	if len(r.data) > largeRecordingBytes {
+		b.Skipf("recording is %d MB; constant pool resolution is measured on recordings under %d MB",
+			len(r.data)>>20, largeRecordingBytes>>20)
+		return true
+	}
+	return false
+}
+
 func filterTo(names ...string) func(*ClassType) bool {
 	set := make(map[string]bool, len(names))
 	for _, n := range names {
@@ -190,6 +214,7 @@ func forEachRecording(b *testing.B, workload func(*benchRecording) (Options, fun
 				}
 			}
 			b.StopTimer()
+			b.ReportMetric(float64(len(rec.data))/(1<<20), "MB_file")
 			if events > 0 {
 				b.ReportMetric(float64(events), "events/op")
 				b.ReportMetric(float64(b.Elapsed().Nanoseconds())/float64(b.N*events), "ns/event")
@@ -294,6 +319,9 @@ func BenchmarkFilteredReused(b *testing.B) {
 func BenchmarkResolveTopFrame(b *testing.B) {
 	var sink string
 	forEachRecording(b, func(rec *benchRecording) (Options, func(*Event)) {
+		if rec.skipIfLarge(b) {
+			return Options{}, nil
+		}
 		return Options{TypeFilter: filterTo(rec.hot)}, func(e *Event) {
 			s, _ := GetString(e.Values, "stackTrace", "frames", 0, "method", "name", "string")
 			sink = s
@@ -308,6 +336,9 @@ func BenchmarkResolveTopFrame(b *testing.B) {
 func BenchmarkResolveDeep(b *testing.B) {
 	var sink map[string]any
 	forEachRecording(b, func(rec *benchRecording) (Options, func(*Event)) {
+		if rec.skipIfLarge(b) {
+			return Options{}, nil
+		}
 		return Options{TypeFilter: filterTo(rec.hot)}, func(e *Event) {
 			sink = ResolveDeepMap(e.Values)
 		}

--- a/go-parser/jfr/recording_test.go
+++ b/go-parser/jfr/recording_test.go
@@ -1,6 +1,9 @@
 package jfr
 
 import (
+	"crypto/sha256"
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -31,24 +34,55 @@ var wellFormedRecordings = []string{
 	"../../demo/src/test/resources/test-dd.jfr",
 }
 
-// availableRecordings returns the well-formed recordings present on disk,
-// deduplicated by file name since get_resources.sh copies the same recordings
-// into two places.
+// availableRecordings returns the well-formed recordings present on disk.
+//
+// It deduplicates by content rather than by file name: get_resources.sh copies
+// the same recordings into two directories, and it also writes one of them
+// under a second name, so a name-based check leaves the parser measuring the
+// same bytes twice. Files that do not carry the JFR magic are skipped, so that
+// a failed or misconfigured download shows up as a missing recording rather
+// than as a parser failure.
 func availableRecordings() []string {
 	var out []string
 	seen := map[string]bool{}
 	for _, path := range wellFormedRecordings {
-		if _, err := os.Stat(path); err != nil {
+		info, err := os.Stat(path)
+		if err != nil {
 			continue
 		}
-		name := filepath.Base(path)
-		if seen[name] {
+		key, err := recordingIdentity(path, info.Size())
+		if err != nil {
 			continue
 		}
-		seen[name] = true
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
 		out = append(out, path)
 	}
 	return out
+}
+
+// recordingIdentity fingerprints a recording by its size and its leading bytes,
+// which is enough to spot a copy without hashing gigabytes. It fails for a file
+// that is not a JFR recording.
+func recordingIdentity(path string, size int64) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	head := make([]byte, 1<<20)
+	n, err := io.ReadFull(f, head)
+	if err != nil && err != io.ErrUnexpectedEOF && err != io.EOF {
+		return "", err
+	}
+	head = head[:n]
+	if len(head) < 4 || string(head[:4]) != "FLR\x00" {
+		return "", fmt.Errorf("%s does not start with the JFR magic", path)
+	}
+	return fmt.Sprintf("%d:%x", size, sha256.Sum256(head)), nil
 }
 
 func openFixture(t *testing.T, path string) *Parser {


### PR DESCRIPTION
The first run of `Go Parser Benchmarks` on main ([run 33864252405](https://github.com/btraceio/jafar/actions/runs/33864252405)) hit the 60-minute job timeout. It got far enough to show why, and what it measured is worth keeping.

## What the run established

Steps 1–7 all passed — including `Test against every available recording` (67 s), so **the parser is correct on the full corpus**, which nothing had previously verified. Only the benchmark step ran out of budget.

The corpus is far larger than what the job was calibrated against:

| Recording | Size | Events |
|---|---:|---:|
| `tck-test.jfr` (in repo) | 2.3 MB | 67 657 |
| `test-ap.jfr` | 179 MB | 2 908 299 |
| `test-jfr.jfr` | 1.78 GB | 10 673 057 |

Every benchmark iteration parses a whole file, so 12 benchmarks × 4 recordings × `benchtime 3x` × `count 3` is **432 full parses**. That was never going to fit.

## Three fixes

**Recordings are deduplicated by content, not by file name.** `get_resources.sh` copies `test-jfr.jfr` to `parser-core/src/test/resources/test-dd.jfr`, so the suite was measuring the same 1.78 GB file twice under two names. The two reported identical event counts (10 673 057) and identical timings, which is what exposed it. Discovery also skips files without the JFR magic now, so a failed download reads as a missing recording rather than as a parser failure.

**The constant-pool resolution benchmarks skip recordings over 256 MB.** `BenchmarkResolveTopFrame` on `test-jfr.jfr` measured **69 s, 69 GB and 494 M allocations for a single iteration**. Resolving one stack frame per event materialises the entire stack-trace pool, which is cached for the life of the chunk, so the cost scales with the pool rather than with the work requested. That is a real property worth knowing — it is now documented in the README as a usage caveat with the mitigation (filter events before resolving) — but it swamps every other benchmark. `JAFAR_BENCH_JFR` still points the suite at such a recording deliberately.

**Unattended runs take one sample per benchmark.** `schedule` and `push` fall back to `benchtime 1x` / `count 1`; a `workflow_dispatch` run keeps `3x`/`3` through the input defaults, since `inputs.*` is empty for the other events. Allocation counts are deterministic and stay exact at one iteration — that is the signal worth tracking over time — while timing at one sample is indicative. Job timeout raised to 90 minutes to leave a manual sweep room.

Benchmarks now also report the file size directly; it previously had to be derived from the throughput figure.

Expected unattended runtime after this: ~5 minutes.

## Two `get_resources.sh` bugs, left alone

Reporting rather than fixing, because neither can be tested from the development environment (Dropbox is blocked by its egress policy):

1. Line 57 copies `$JFR_FILE` to `parser-core/src/test/resources/test-dd.jfr`, where `$DD_JFR_FILE` is presumably meant.
2. `DD_JFR_URL` ends in `dl=0`, which serves Dropbox's HTML preview page rather than the file — the other two URLs use `dl=1`.

No Java test consumes `test-dd.jfr`, so neither is currently load-bearing. With the content-based dedup in this PR, the benchmark suite is correct either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DMapvTSorQHEvKb8zjAdMW

---
_Generated by [Claude Code](https://claude.ai/code/session_01DMapvTSorQHEvKb8zjAdMW)_