### PR TITLE
Stop the benchmark job exhausting the runner's memory

### DIFF
--- a/go-parser/README.md
+++ b/go-parser/README.md
@@ -140,30 +140,35 @@ pool and stay valid either way.
 ### On large recordings
 
 Measured on the benchmark corpus `./get_resources.sh` downloads, on a GitHub
-`ubuntu-latest` runner:
+`ubuntu-latest` runner (AMD EPYC 7763), one iteration per benchmark:
 
-| Recording | Size | Events | Decode one type, two fields, `ReuseValues` |
-|---|---:|---:|---|
-| `test-ap.jfr` | 179 MB | 2 908 299 | 1.94 s, 668 ns/event, 45 MB, 2.9 M allocs |
-| `test-jfr.jfr` | 1.78 GB | 10 673 057 | 13.95 s, 1307 ns/event, 422 MB, 21.7 M allocs |
+| Recording | Size | Events | Decode every event | …with `ReuseValues` |
+|---|---:|---:|---|---|
+| `tck-test.jfr` | 2.2 MiB | 67 657 | 44.8 ms, 44.5 MB, 505 k allocs | 35.3 ms, **3.0 MB**, 217 k allocs |
+| `test-ap.jfr` | 171 MiB | 2 914 799 | 2.27 s, 1.26 GB, 11.7 M allocs | 1.94 s, **45 MB**, 3.0 M allocs |
+| `test-jfr.jfr` | 1.65 GiB | 12 972 157 | 15.98 s, 5.89 GB, 67.9 M allocs | 14.74 s, **486 MB**, 28.6 M allocs |
 
-Per-event cost stays flat as the recording grows, which is the property that
-matters. One thing does not, and it is worth knowing before you write a
-consumer:
+Per-event cost stays flat as the recording grows — 663, 778 and 1232 ns/event
+respectively — and `ReuseValues` removes 92–96% of the bytes at every size. That
+is the property that matters.
 
-**Resolving a constant pool reference on every event materialises the whole
-pool.** Entries are cached for the life of the chunk, so reading one stack frame
-per event pulls the entire stack trace, frame, method and symbol graph into
-memory and keeps it there. On `tck-test.jfr` (14 202 events) that costs 21 ms
-and 153 k allocations; on `test-jfr.jfr` (10.7 M events) the same one-line
-access costs **69 s and 494 M allocations**, because the pool it is filling is
-three orders of magnitude larger. The caching is what makes the common case
-fast - a stack trace shared by ten thousand events is decoded once - but it
-scales with the pool, not with the work you asked for.
+One thing does not scale, and it is worth knowing before you write a consumer:
 
-If you only need a few stack traces out of many events, filter the events down
-first (`TypeFilter`, or a predicate in the handler) and resolve only what
-survives.
+**Resolving a constant pool reference on every event pulls the whole pool into
+memory.** Entries are cached for the life of the chunk, so reading one stack
+frame per event materialises the entire stack trace, frame, method and symbol
+graph and keeps it there. The same one-line access costs 23 ms and 153 k
+allocations on `tck-test.jfr` (14 202 events), **12 s and 11 GB** on
+`test-ap.jfr` (2.9 M events), and **69 s and 69 GB** on `test-jfr.jfr` (10.7 M
+events). `ResolveDeep` additionally retains a materialised copy per entry, and
+exhausted a 16 GB CI runner on the 171 MiB recording.
+
+The caching is what makes the common case fast — a stack trace shared by ten
+thousand events is decoded once — but it is unbounded and scales with the pool,
+not with the work you asked for. If you need stack traces from a subset of
+events, filter the events down first (`TypeFilter`, or a predicate in the
+handler) and resolve only what survives. If you need them from all events of a
+multi-gigabyte recording, budget the memory for the whole pool.
 
 Two other things matter more than they look:
 

--- a/go-parser/jfr/bench_test.go
+++ b/go-parser/jfr/bench_test.go
@@ -156,15 +156,21 @@ func (r *benchRecording) profile() error {
 // largeRecordingBytes is the size above which the constant-pool resolution
 // benchmarks skip a recording.
 //
-// Resolving one stack frame per event forces the whole stack trace pool into
-// memory, and the pool is cached for the life of the chunk, so the cost grows
-// with the recording rather than with the work asked of it: on a 1.8 GB
-// recording BenchmarkResolveTopFrame measured 69 s, 69 GB and 494 M allocations
-// for a single iteration. That is a real property of the parser worth knowing,
-// but it is not a routine regression check - it swamps every other benchmark in
-// the suite. Point the suite at one such recording deliberately
-// (JAFAR_BENCH_JFR) when that is what you want to measure.
-const largeRecordingBytes = 256 << 20
+// Resolving a constant pool reference on every event pulls the whole pool into
+// memory: entries are cached for the life of the chunk, so the cost grows with
+// the pool rather than with the work asked of it. Measured on a GitHub runner,
+// one iteration of BenchmarkResolveTopFrame cost 69 s and 69 GB on a 1.7 GiB
+// recording, and 12 s and 11 GB on a 171 MiB one; BenchmarkResolveDeep, which
+// also retains a materialised copy per entry, exhausted the runner's memory on
+// that same 171 MiB recording and the job was killed with SIGTERM.
+//
+// The threshold therefore sits below the smallest recording in the downloaded
+// corpus: constant pool resolution is measured on the reference recording in
+// the repository, which is the stable regression signal, and skipped on
+// anything large enough to turn the benchmark into a memory-exhaustion test.
+// Point the suite at a large recording deliberately (JAFAR_BENCH_JFR) when
+// measuring that behaviour is the actual goal - and give it room to run.
+const largeRecordingBytes = 64 << 20
 
 // skipIfLarge skips a constant-pool resolution benchmark on a recording big
 // enough for it to dominate the run.


### PR DESCRIPTION
Benchmark [run #2](https://github.com/btraceio/jafar/actions/runs/33871472937) on main confirmed everything #112 set out to fix — and then died a different way.

## What #112 got right

- Content dedup worked: **3 recordings, not 4**. The two 1.7 GiB entries (`test-jfr.jfr` and its copy `test-dd.jfr`) collapsed into one.
- Constant-pool benchmarks skipped the 1.65 GiB recording.
- The benchmark step finished in **4 m 11 s** instead of running past 60 minutes.
- Sizes are now reported directly rather than derived from throughput.

## What killed it

```
##[error]The runner has received a shutdown signal.
##[error]Process completed with exit code 143.
```

SIGTERM, partway through `BenchmarkResolveDeep` on the **171 MiB** `test-ap.jfr` — the recording the 256 MB threshold let through.

Resolving a constant pool reference on every event materialises the whole pool and keeps it for the life of the chunk. On that recording one iteration of `BenchmarkResolveTopFrame` allocated **11 GB across 78 M allocations**; `ResolveDeep`, which additionally retains a materialised copy per entry, exhausted the runner.

The threshold drops to **64 MB** — below the smallest recording in the downloaded corpus. Constant-pool resolution is measured on the reference recording in the repository, which is the stable regression signal, and skipped on anything large enough to turn the benchmark into a memory-exhaustion test. `JAFAR_BENCH_JFR` still points the suite at a large recording deliberately, for a machine with room to run it.

## The numbers, recorded

These are the first measurements from real recordings rather than ones I generated locally, so the README now carries them:

| Recording | Size | Events | Decode every event | …with `ReuseValues` |
|---|---:|---:|---|---|
| `tck-test.jfr` | 2.2 MiB | 67 657 | 44.8 ms, 44.5 MB, 505 k allocs | 35.3 ms, **3.0 MB**, 217 k allocs |
| `test-ap.jfr` | 171 MiB | 2 914 799 | 2.27 s, 1.26 GB, 11.7 M allocs | 1.94 s, **45 MB**, 3.0 M allocs |
| `test-jfr.jfr` | 1.65 GiB | 12 972 157 | 15.98 s, 5.89 GB, 67.9 M allocs | 14.74 s, **486 MB**, 28.6 M allocs |

Per-event cost is flat across three orders of magnitude of recording size — 663, 778 and 1232 ns/event — and `ReuseValues` removes **92–96% of the bytes at every size**.

The unbounded constant-pool cache is documented alongside them as a usage caveat, with the mitigation: filter events before resolving, or budget the memory for the whole pool.

## Worth a separate conversation

The OOM is a benchmark-harness problem, fixed here. But it surfaces a real property of the parser: **the constant-pool caches are unbounded and chunk-scoped**. A consumer resolving stack traces across a multi-gigabyte recording will hold the entire decoded pool. Bounding it (an LRU, or an opt-out of caching) is a design decision with a performance trade-off, so it is documented rather than changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DMapvTSorQHEvKb8zjAdMW

---
_Generated by [Claude Code](https://claude.ai/code/session_01DMapvTSorQHEvKb8zjAdMW)_